### PR TITLE
[#318] Changes to ZSYSTEM_FILTER/PIPE_FILTER in restrict.txt are ignored if they happen within 1 second

### DIFF
--- a/sr_port/restrict.c
+++ b/sr_port/restrict.c
@@ -71,11 +71,11 @@ error_def(ERR_TEXT);
 	if (!ACCESS(FPATH,F_OK))		/*Filter file exists, now check modified time*/			\
 	{													\
 		Stat(RPATH, &rTime);										\
-		rmtime = rTime.st_mtime;									\
+		rmtime = rTime.st_mtim;										\
 		Stat(FPATH, &fTime);										\
-		fmtime = fTime.st_mtime;									\
-		if (rmtime > fmtime)	/*Delete the older mapping file and recreate new if required*/		\
-		{												\
+		fmtime = fTime.st_mtim;										\
+		if ((rmtime.tv_sec > fmtime.tv_sec) || (rmtime.tv_nsec >= fmtime.tv_nsec))			\
+		{	/*Delete the older mapping file and recreate new if required*/				\
 			created_now = TRUE;									\
 			gtm_file_remove(FPATH, strlen(FPATH), &STAT_RM);					\
 			append_filter(FPATH, FP, C_CALL_NAME, M_REF_NAME, SAVE_ERRNO, ERR_STR);			\
@@ -125,7 +125,7 @@ void restrict_init(void)
 	size_t		grpbufsz;
 	boolean_t	created_now = FALSE;
 	struct stat 	rTime, fTime;
-	time_t 		rmtime, fmtime;
+	struct timespec	rmtime, fmtime;
 
 	assert(!restrict_initialized);
 	assert(ydb_dist_ok_to_use);


### PR DESCRIPTION
M labelrefs specified in ZSYSTEM_FILTER/PIPE_FILTER in $ydb_dist/restrict.txt were stored in a table format
suitable for a call-in invocation in the file $ydb_dist/filter_commands.tab. Any newer changes to restrict.txt
relative to filter_commands.tab required recreating filter_commands.tab. This check was done using 1-second
level timestamp granularity which is too coarse. This is now fixed to do nanosecond-level timestamp checking.
That ensures multiple changes to restrict.txt within the same second result in recreation of filter_commands.tab.

In addition, if the timestamp matches at the nanosecond level, a recreation is done (whereas previously
if the timestamp at the second level matched, no recreation was done). This is a just-to-be-safe change.