### PR TITLE
Added feature NEW $TEST

### DIFF
--- a/sr_port/gbldefs.c
+++ b/sr_port/gbldefs.c
@@ -233,7 +233,8 @@ GBLDEF	mval		dollar_zgbldir,
 			dollar_estack_delta = DEFINE_MVAL_STRING(MV_STR, 0, 0, 0, NULL, 0, 0),
 			dollar_zerror = DEFINE_MVAL_STRING(MV_STR, 0, 0, DEFAULT_ZERROR_LEN, DEFAULT_ZERROR_STR, 0, 0),
 			dollar_zyerror,
-			dollar_ztexit = DEFINE_MVAL_STRING(MV_STR, 0, 0, 0, NULL, 0, 0);
+			dollar_ztexit = DEFINE_MVAL_STRING(MV_STR, 0, 0, 0, NULL, 0, 0),
+			dollar_testv = DEFINE_MVAL_STRING(MV_NM | MV_INT, 0, 0, 0, 0, 0, 0); /* NEW $TEST */
 GBLDEF  uint4		dollar_zjob;
 GBLDEF	mval		dollar_zinterrupt;
 GBLDEF	boolean_t	dollar_zininterrupt;

--- a/sr_port/m_new.c
+++ b/sr_port/m_new.c
@@ -89,6 +89,7 @@ int m_new(void)
 				case SV_ESTACK:
 				case SV_ZYERROR:
 				case SV_ZGBLDIR:
+				case SV_TEST: /* NEW $TEST */
 				GTMTRIG_ONLY(case SV_ZTWORMHOLE:)
 					tmp = maketriple(OC_NEWINTRINSIC);
 					tmp->operand[0] = put_ilit(svn_data[n].opcode);

--- a/sr_port/op_newintrinsic.c
+++ b/sr_port/op_newintrinsic.c
@@ -39,6 +39,9 @@ GBLREF int4		gtm_trigger_depth;
 GBLREF mval		dollar_ztwormhole;
 #endif
 
+GBLREF mval		dollar_testv; /* NEW $TEST */
+GBLREF int 		dollar_truth; /* NEW $TEST */
+
 error_def(ERR_NOZTRAPINTRIG);
 
 /* Routine to NEW a special intrinsic variable. Note that gtm_newinstrinsic(),
@@ -90,6 +93,10 @@ void op_newintrinsic(int intrtype)
 			intrinsic = &dollar_ztwormhole;
 			break;
 #		endif
+		case SV_TEST: /* NEW TEST */
+			dollar_testv.m[1] = dollar_truth ? 1000 : 0;
+			intrinsic = &dollar_testv; 
+			break;
 		default:	/* Only above types defined by compiler */
 			assertpro(FALSE && intrtype);
 	}

--- a/sr_port/stp_gcol_src.h
+++ b/sr_port/stp_gcol_src.h
@@ -93,6 +93,7 @@ GBLREF mliteral			literal_chain;
 GBLREF mstr			*comline_base, **stp_array;
 GBLREF mval			dollar_system, dollar_zerror, dollar_zgbldir, dollar_zstatus;
 GBLREF mval			dollar_zyerror, zstep_action, dollar_zinterrupt, dollar_zsource, dollar_ztexit;
+GBLREF mval			dollar_testv; /* NEW $TEST */
 GBLREF mv_stent			*mv_chain;
 GBLREF sgm_info			*first_sgm_info;
 GBLREF spdesc			indr_stringpool, rts_stringpool, stringpool;
@@ -725,6 +726,7 @@ void stp_gcol(size_t space_asked)	/* BYPASSOK */
 		MVAL_STPG_ADD(&dollar_ztwormhole);
 #		endif
 		MVAL_STPG_ADD(TADR(last_fnquery_return_varname));
+		MVAL_STPG_ADD(&dollar_testv); /* NEW $TEST */
 		for (index = 0; index < TREF(last_fnquery_return_subcnt); index++)
 			MVAL_STPG_ADD(&TAREF1(last_fnquery_return_sub, index));
 		for (mvs = mv_chain; mvs < (mv_stent *)stackbase; mvs = (mv_stent *)((char *)mvs + mvs->mv_st_next))

--- a/sr_port/unw_mv_ent.c
+++ b/sr_port/unw_mv_ent.c
@@ -104,6 +104,9 @@ GBLREF zshow_out		*zwr_output;
 GBLREF zwr_hash_table		*zwrhtab;
 GBLREF boolean_t		tp_timeout_deferred;
 
+GBLREF mval			dollar_testv; /* NEW $TEST */
+GBLREF int 			dollar_truth; /* NEW $TEST */
+
 #define FREEIFALLOC(ADR) if (NULL != (ADR)) free(ADR)
 
 void unw_mv_ent(mv_stent *mv_st_ent)
@@ -134,6 +137,12 @@ void unw_mv_ent(mv_stent *mv_st_ent)
 	{
 		case MVST_MSAV:
 			*mv_st_ent->mv_st_cont.mvs_msav.addr = mv_st_ent->mv_st_cont.mvs_msav.v;
+		        /* NEW $TEST beg */
+			if (&dollar_testv == mv_st_ent->mv_st_cont.mvs_msav.addr)
+			{
+			    dollar_truth  = dollar_testv.m[1] ? 1 : 0;
+			} else
+			/*NEW $TEST end*/
 			if (&(TREF(dollar_etrap)) == mv_st_ent->mv_st_cont.mvs_msav.addr)
 			{
 				ztrap_explicit_null = FALSE;


### PR DESCRIPTION
In the classes of the Intersystems Cache, the operation of a New $TEST is done implicitly,
which makes it difficult to transfer them to YotaDB.
In addition, the use of New $TEST in functions will allow you to
avoid errors in the constructions of IF ... Else
.