### PR TITLE
Improving TTY IO functionality.  Some code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /fuzzing/output/
 /fuzzing/env/
 /fuzzing/NotMinCorpus/
+.vscode/
+YDB_FATAL*

--- a/sr_port/io.h
+++ b/sr_port/io.h
@@ -149,7 +149,7 @@ typedef struct io_desc_struct
 		int		devicebufferlen;
 	}dollar;
 	unsigned char			esc_state;
-	void				*dev_sp;
+	void				*dev_sp;	//kt doc: used variantly to hold: d_us_struct*, d_rm_struct*, d_socket_struct*, or d_tt_struct*
 	struct dev_dispatch_struct	*disp_ptr;
 #if defined(KEEP_zOS_EBCDIC)
 	iconv_t				input_conv_cd;
@@ -191,7 +191,7 @@ typedef struct io_desc_struct
  * First WRITE: Do not WRITE BOM. All output in specified endian format
  */
 
-typedef struct io_log_name_struct
+typedef struct io_log_name_struct		//kt doc: "log" means *logical* record.
 {
 	io_desc		*iod;		/* io descriptor	*/
 	struct io_log_name_struct
@@ -226,7 +226,7 @@ typedef struct dev_dispatch_struct
 
 /* io_ prototypes */
 void io_rundown(int rundown_type);
-void io_init(boolean_t term_ctrl);
+void io_init(boolean_t ctrlc_enable);		//kt renamed "term_ctrl" to "ctrlc_enable" for consistency across codebase.
 bool io_is_rm(mstr *name);
 bool io_is_sn(mstr *tn);
 struct mv_stent_struct *io_find_mvstent(io_desc *io_ptr, boolean_t clear_mvstent);
@@ -397,10 +397,18 @@ LITREF unsigned char ebcdic_spaces_block[];
 }
 #define SET_ENCODING(CHSET, CHSET_MSTR)	SET_ENCODING_VALIDATE(CHSET, CHSET_MSTR,)
 
+/*  //kt Original version below.
 #define GET_ADDR_AND_LEN(ADDR, LEN)												\
 {																\
 	ADDR = (char *)(pp->str.addr + p_offset + 1);										\
 	LEN = (int)(*(pp->str.addr + p_offset));										\
+}
+*/
+//kt replaced macro above, changing to new version below, adding 2 additional input parameters to remove dependence on local scope
+#define GET_ADDR_AND_LEN(STRUCT, OFFSET, ADDR, LEN)  										\
+{                                             											\
+    ADDR = (char *)((STRUCT)->str.addr + OFFSET + 1); 										\
+    LEN = (int)(*(STRUCT)->str.addr + OFFSET);        										\
 }
 
 /* Set the UTF-16 variant IFF not already set. Use the UTF16 variant to set the new CHSET (for SOCKET devices) */

--- a/sr_port/io_rundown.c
+++ b/sr_port/io_rundown.c
@@ -71,6 +71,7 @@ void io_rundown (int rundown_type)
 				 * If so do "iott_resetterm" to restore terminal to what it was (undo whatever stty settings
 				 * YottaDB changed in terminal).
 				 */
+				//kt doc:  Leaving application.  If terminal needs additional restoration, could add here...
 				RESETTERM_IF_NEEDED(ioptr, EXPECT_SETTERM_DONE_FALSE);
 			}
 		}

--- a/sr_port/ionl_open.c
+++ b/sr_port/ionl_open.c
@@ -34,7 +34,7 @@ LITREF unsigned char io_params_size[];
 short ionl_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 timeout)
 {
 	unsigned char	ch;
-	io_desc		*d_out, *ioptr;
+	io_desc		*d_out, *io_ptr;   //kt renamed "ioptr" to "io_ptr" for consistency across codebase.  Changes below not marked.  Just search for "io_ptr"
 	int		p_offset, status;
 	DCL_THREADGBL_ACCESS;
 
@@ -49,16 +49,16 @@ short ionl_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 		if (0 <= fd)
 		        CLOSEFILE_RESET(fd, status);	/* resets "fd" to FD_INVALID */
 	);
-	ioptr = dev_name->iod;
-	ioptr->state = dev_open;
-	d_out = ioptr->pair.out;
-	ioptr->length = DEF_NL_LENGTH;
-	ioptr->width = DEF_NL_WIDTH;
-	ioptr->wrap = TRUE;
-	ioptr->dollar.za = 0;
-	ioptr->dollar.zeof = FALSE;
-	ioptr->dollar.x = 0;
-	ioptr->dollar.y = 0;
+	io_ptr = dev_name->iod;
+	io_ptr->state = dev_open;
+	d_out = io_ptr->pair.out;
+	io_ptr->length = DEF_NL_LENGTH;
+	io_ptr->width = DEF_NL_WIDTH;
+	io_ptr->wrap = TRUE;
+	io_ptr->dollar.za = 0;
+	io_ptr->dollar.zeof = FALSE;
+	io_ptr->dollar.x = 0;
+	io_ptr->dollar.y = 0;
 	while (*(pp->str.addr + p_offset) != iop_eol)
 	{
 		ch = *(pp->str.addr + p_offset++);
@@ -71,7 +71,7 @@ short ionl_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 			d_out->wrap = FALSE;
 			break;
 		case iop_exception:
-			DEF_EXCEPTION(pp, p_offset, ioptr);
+			DEF_EXCEPTION(pp, p_offset, io_ptr);
 			break;
 		default:
 			break;

--- a/sr_port/iosocket_open.c
+++ b/sr_port/iosocket_open.c
@@ -70,7 +70,8 @@ error_def(ERR_ZINTRECURSEIO);
 
 #define ESTABLISHED		"ESTABLISHED"
 
-short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint8 timepar)
+short	iosocket_open(io_log_name *dev, mval *devparms, int file_des, mval *mspace, uint8 timepar)
+//kt NOTE: renamed variable "pp" -> "devparms", here and many spots below.  Each change was not marked, so search for devparms for location of changes.
 {
 	char			addr[SA_MAXLITLEN], *errptr, sockaddr[SA_MAXLITLEN],
 				temp_addr[SA_MAXLITLEN], dev_type[MAX_DEV_TYPE_LEN];
@@ -82,7 +83,7 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 	int4			options_len = 0;
 	int			d_socket_struct_len, soc_cnt;
 	ABS_TIME		cur_time, end_time;
-	io_desc			*ioptr;
+	io_desc			*io_ptr;   //kt renamed "ioptr" to "io_ptr" for consistency across codebase.  Changes below not marked.  Just search for "io_ptr"
 	fd_set			tcp_fd;
 	uint4			bfsize = DEFAULT_SOCKET_BUFFER_SIZE, ibfsize;
 	d_socket_struct		*dsocketptr;
@@ -120,37 +121,37 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 	DCL_THREADGBL_ACCESS;
 
 	SETUP_THREADGBL_ACCESS;
-	ioptr = dev->iod;
-	ESTABLISH_RET_GTMIO_CH(&ioptr->pair, -1, ch_set);
-	assert((params) *(pp->str.addr + p_offset) < (unsigned char)n_iops);
-	assert(ioptr != 0);
-	assert(ioptr->state >= 0 && ioptr->state < n_io_dev_states);
-	assert(ioptr->type == gtmsocket);
-	if ((ioptr->state == dev_closed) && mspace && mspace->str.len && mspace->str.addr)
+	io_ptr = dev->iod;
+	ESTABLISH_RET_GTMIO_CH(&io_ptr->pair, -1, ch_set);
+	assert((params) *(devparms->str.addr + p_offset) < (unsigned char)n_iops);
+	assert(io_ptr != 0);
+	assert(io_ptr->state >= 0 && io_ptr->state < n_io_dev_states);
+	assert(io_ptr->type == gtmsocket);
+	if ((io_ptr->state == dev_closed) && mspace && mspace->str.len && mspace->str.addr)
 	{
 		lower_to_upper((uchar_ptr_t)dev_type, (uchar_ptr_t)mspace->str.addr, MIN(mspace->str.len, SIZEOF(dev_type)));
 		if (STR_LIT_LEN("SOCKET") != mspace->str.len || 0 != memcmp(dev_type, "SOCKET", STR_LIT_LEN("SOCKET")))
 		{
-			if (ioptr->dev_sp)
-				free(ioptr->dev_sp);
-			ioptr->state = dev_never_opened;
+			if (io_ptr->dev_sp)
+				free(io_ptr->dev_sp);
+			io_ptr->state = dev_never_opened;
 		}
 	}
 	d_socket_struct_len = SIZEOF(d_socket_struct) + (SIZEOF(socket_struct) * (ydb_max_sockets - 1));
-	if (ioptr->state == dev_never_opened)
+	if (io_ptr->state == dev_never_opened)
 	{
-		dsocketptr = ioptr->dev_sp = (void *)malloc(d_socket_struct_len);
-		ioptr->newly_created = TRUE;
+		dsocketptr = io_ptr->dev_sp = (void *)malloc(d_socket_struct_len);
+		io_ptr->newly_created = TRUE;
 		memset(dsocketptr, 0, d_socket_struct_len);
-		dsocketptr->iod = ioptr;
+		dsocketptr->iod = io_ptr;
 	} else
-		dsocketptr = (d_socket_struct *)ioptr->dev_sp;
-	if (ioptr->state == dev_never_opened)
+		dsocketptr = (d_socket_struct *)io_ptr->dev_sp;
+	if (io_ptr->state == dev_never_opened)
 	{
-		ioptr->state	= dev_closed;
-		ioptr->width	= TCPDEF_WIDTH;
-		ioptr->length	= TCPDEF_LENGTH;
-		ioptr->wrap	= TRUE;
+		io_ptr->state	= dev_closed;
+		io_ptr->width	= TCPDEF_WIDTH;
+		io_ptr->length	= TCPDEF_LENGTH;
+		io_ptr->wrap	= TRUE;
 		dsocketptr->current_socket = -1;	/* 1st socket is 0 */
 		if ((2 > file_des) && (0 <= file_des) && (!io_std_device.in || !io_std_device.out))
 			/* called from io_init */
@@ -180,8 +181,8 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 			socketptr = newdsocket->socket[newdsocket->current_socket];
 			ichset_specified = newdsocket->ichset_specified;
 			ochset_specified = newdsocket->ochset_specified;
-			temp_ichset = ioptr->ichset;
-			temp_ochset = ioptr->ochset;
+			temp_ichset = io_ptr->ichset;
+			temp_ochset = io_ptr->ochset;
 			assert(socketptr == (socket_struct *)mv_zintdev->mv_st_cont.mvs_zintdev.socketptr);
 			zint_conn_restart = TRUE;	/* skip what we already did, state == dev_closed */
 		} else
@@ -191,25 +192,25 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 		}
 	} else
 	{
-		ioptr->dollar.zeof = FALSE;
+		io_ptr->dollar.zeof = FALSE;
 		if (NULL == newdsocket)
 			newdsocket = (d_socket_struct *)malloc(d_socket_struct_len);
 		memcpy(newdsocket, dsocketptr, d_socket_struct_len);
-		memcpy(ioptr->dollar.device, "0", SIZEOF("0"));
+		memcpy(io_ptr->dollar.device, "0", SIZEOF("0"));
 		zff_len = -1; /* indicates neither ZFF nor ZNOFF specified */
 		delimiter_len = -1; /* indicates neither DELIM nor NODELIM specified */
 		filemode = filemode_mask = 0;
 		uic.mem = (uid_t)-1;		/* flag as not specified */
 		uic.grp = (gid_t)-1;
 		ichset_specified = ochset_specified = FALSE;
-		while (iop_eol != (ch = *(pp->str.addr + p_offset++)))
+		while (iop_eol != (ch = *(devparms->str.addr + p_offset++)))
 		{
 			switch(ch)
 			{
 				case iop_delimiter:
-					delimiter_len = (int4)(unsigned char)(*(pp->str.addr + p_offset));
+					delimiter_len = (int4)(unsigned char)(*(devparms->str.addr + p_offset));
 					if (((MAX_DELIM_LEN + 1) * MAX_N_DELIMITER) >= delimiter_len)
-						memcpy(delimiter_buffer, (pp->str.addr + p_offset + 1), delimiter_len);
+						memcpy(delimiter_buffer, (devparms->str.addr + p_offset + 1), delimiter_len);
 					else
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(1) ERR_DELIMSIZNA);
 					break;
@@ -217,7 +218,8 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 					UTF8_ONLY(
 						if (gtm_utf8_mode)
 						{	/* Only change ipchset if in UTF8 mode */
-							GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+							//kt original --> GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+							GET_ADDR_AND_LEN(devparms, p_offset, chset_mstr.addr, chset_mstr.len);  //kt
 							SET_ENCODING(temp_ichset, &chset_mstr)
 							ichset_specified = TRUE;
 						}
@@ -227,7 +229,8 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 					UTF8_ONLY(
 						if (gtm_utf8_mode)
 						{       /* Only change ipchset if in UTF8 mode */
-							GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+							//kt original --> GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+							GET_ADDR_AND_LEN(devparms, p_offset, chset_mstr.addr, chset_mstr.len);  //kt
 							SET_ENCODING(temp_ochset, &chset_mstr)
 							ochset_specified = TRUE;
 						}
@@ -237,7 +240,8 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 					UTF8_ONLY(
 						if (gtm_utf8_mode)
 						{       /* Only change ipchset/opchset if in UTF8 mode */
-							GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+							//kt original --> GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+							GET_ADDR_AND_LEN(devparms, p_offset, chset_mstr.addr, chset_mstr.len);  //kt
 							SET_ENCODING(temp_ichset, &chset_mstr)
 							temp_ochset = temp_ichset;
 							ichset_specified = ochset_specified = TRUE;
@@ -291,61 +295,61 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 					nodelay_specified = TRUE;
 					break;
 				case iop_zbfsize:
-					GET_ULONG(bfsize, pp->str.addr + p_offset);
+					GET_ULONG(bfsize, devparms->str.addr + p_offset);
 					if ((0 == bfsize) || (MAX_SOCKET_BUFFER_SIZE < bfsize))
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(3) ERR_ILLESOCKBFSIZE, 1, bfsize);
 					break;
 				case iop_zibfsize:
 					ibfsize_specified = TRUE;
-					GET_ULONG(ibfsize, pp->str.addr + p_offset);
+					GET_ULONG(ibfsize, devparms->str.addr + p_offset);
 					if (0 == ibfsize)
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(3) ERR_ILLESOCKBFSIZE, 1, bfsize);
 					break;
 				case iop_zlisten:
 					listen_specified = TRUE;
-					len = (int)(unsigned char)(*(pp->str.addr + p_offset));
+					len = (int)(unsigned char)(*(devparms->str.addr + p_offset));
 					if (len < SA_MAXLITLEN)
 					{
 						memset(sockaddr, 0, SIZEOF(sockaddr));
 						assert((0 < len) && (SIZEOF(sockaddr) >= len));
-						memcpy(sockaddr, pp->str.addr + p_offset + 1, len);
+						memcpy(sockaddr, devparms->str.addr + p_offset + 1, len);
 					} else
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(6) ERR_ADDRTOOLONG, 4, len,
-							pp->str.addr + p_offset + 1, len, SA_MAXLITLEN - 1);
+							devparms->str.addr + p_offset + 1, len, SA_MAXLITLEN - 1);
 					break;
 				case iop_connect:
 					connect_specified = TRUE;
-					len = (int)(unsigned char)(*(pp->str.addr + p_offset));
+					len = (int)(unsigned char)(*(devparms->str.addr + p_offset));
 					if (len < SA_MAXLITLEN)
 					{
 						memset(sockaddr, 0, SIZEOF(sockaddr));
 						assert((0 < len) && (SIZEOF(sockaddr) >= len));
-						memcpy(sockaddr, pp->str.addr + p_offset + 1, len);
+						memcpy(sockaddr, devparms->str.addr + p_offset + 1, len);
 					} else
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(6) ERR_ADDRTOOLONG, 4,
-							len, pp->str.addr + p_offset + 1, len, SA_MAXLITLEN - 1);
+							len, devparms->str.addr + p_offset + 1, len, SA_MAXLITLEN - 1);
 					break;
 				case iop_ioerror:
 					ioerror_specified = TRUE;
-					ioerror = *(pp->str.addr + p_offset + 1);	/* the first char decides */
+					ioerror = *(devparms->str.addr + p_offset + 1);	/* the first char decides */
 					break;
 				case iop_exception:
-					DEF_EXCEPTION(pp, p_offset, ioptr);
+					DEF_EXCEPTION(devparms, p_offset, io_ptr);
 					break;
 				case iop_attach:
 					attach_specified = TRUE;
-					handle_len = (int)(unsigned char)(*(pp->str.addr + p_offset));
+					handle_len = (int)(unsigned char)(*(devparms->str.addr + p_offset));
 					if (handle_len > MAX_HANDLE_LEN)
 						handle_len = MAX_HANDLE_LEN;
 					assert((0 < handle_len) && (SIZEOF(sock_handle) >= handle_len));
-					memcpy(sock_handle, pp->str.addr + p_offset + 1, handle_len);
+					memcpy(sock_handle, devparms->str.addr + p_offset + 1, handle_len);
 					break;
 				case iop_socket:
 					RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(1) ERR_DEVPARINAP);
 					break;
 				case iop_zff:
-					if (MAX_ZFF_LEN >= (zff_len = (int4)(unsigned char)(*(pp->str.addr + p_offset))))
-						memcpy(zff_buffer, (char *)(pp->str.addr + p_offset + 1), zff_len);
+					if (MAX_ZFF_LEN >= (zff_len = (int4)(unsigned char)(*(devparms->str.addr + p_offset))))
+						memcpy(zff_buffer, (char *)(devparms->str.addr + p_offset + 1), zff_len);
 					else
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_ZFF2MANY, 2, zff_len, MAX_ZFF_LEN);
 					break;
@@ -353,14 +357,14 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 					zff_len = 0;
 					break;
 				case iop_wrap:
-					ioptr->wrap = TRUE;
+					io_ptr->wrap = TRUE;
 					break;
 				case iop_nowrap:
-					ioptr->wrap = FALSE;
+					io_ptr->wrap = FALSE;
 					break;
 				case iop_morereadtime:
 					/* Time in milliseconds socket read will wait for more data before returning */
-					GET_LONG(moreread_timeout, pp->str.addr + p_offset);
+					GET_LONG(moreread_timeout, devparms->str.addr + p_offset);
 					if (-1 == moreread_timeout)
 						moreread_timeout = DEFAULT_MOREREAD_TIMEOUT;
 					else if (-1 > moreread_timeout)
@@ -374,8 +378,8 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 					newversion = TRUE;
 					break;
 				case iop_uic:
-					start = (unsigned char *)pp->str.addr + p_offset;
-					top = (unsigned char *)pp->str.addr + p_offset + 1 + *start;
+					start = (unsigned char *)devparms->str.addr + p_offset;
+					top = (unsigned char *)devparms->str.addr + p_offset + 1 + *start;
 					next = ++start;		/* past length */
 					uicvalue = 0;
 					while ((',' != *next) && (('0' <= *next) && ('9' >= *next)) && (next < top))
@@ -394,29 +398,29 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 					break;
 				case iop_w_protection:
 					filemode_mask |= S_IRWXO;
-					filemode |= (uint)(unsigned char)*(pp->str.addr + p_offset);
+					filemode |= (uint)(unsigned char)*(devparms->str.addr + p_offset);
 					break;
 				case iop_g_protection:
 					filemode_mask |= S_IRWXG;
-					filemode |= (uint)(unsigned char)*(pp->str.addr + p_offset) << 3;
+					filemode |= (uint)(unsigned char)*(devparms->str.addr + p_offset) << 3;
 					break;
 				case iop_s_protection:
 				case iop_o_protection:
 					filemode_mask |= S_IRWXU;
-					filemode |= (uint)(unsigned char)*(pp->str.addr + p_offset) << 6;
+					filemode |= (uint)(unsigned char)*(devparms->str.addr + p_offset) << 6;
 					break;
 				case iop_options:
-					options_len = (int4)(unsigned char)*(pp->str.addr + p_offset);
+					options_len = (int4)(unsigned char)*(devparms->str.addr + p_offset);
 					if (UCHAR_MAX >= options_len)
 					{
-						memcpy(options_buffer, (unsigned char *)(pp->str.addr + p_offset + 1), options_len);
+						memcpy(options_buffer, (unsigned char *)(devparms->str.addr + p_offset + 1), options_len);
 						options_buffer[options_len] = '\0';
 					}
 					break;
 				default:
 					break;
 			}
-			UPDATE_P_OFFSET(p_offset, ch, pp);	/* updates "p_offset" using "ch" and "pp" */
+			UPDATE_P_OFFSET(p_offset, ch, devparms);	/* updates "p_offset" using "ch" and "devparms" */
 		}
 		if (listen_specified && connect_specified)
 		{
@@ -432,17 +436,17 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 		}
 		if (listen_specified || connect_specified || is_principal)
 		{	/* CHSET cannot be specified when opening a new socket, if there already are open sockets. */
-			if (0 < dsocketptr->n_socket && ((ochset_specified && (temp_ochset != ioptr->ochset))
-				|| (ichset_specified && (temp_ichset != ioptr->ichset))))
+			if (0 < dsocketptr->n_socket && ((ochset_specified && (temp_ochset != io_ptr->ochset))
+				|| (ichset_specified && (temp_ichset != io_ptr->ichset))))
 			{
 				rts_error_csa(CSA_ARG(NULL) VARLSTCNT(10) ERR_CHSETALREADY, 8,
-					chset_names[ioptr->ichset].len, chset_names[ioptr->ichset].addr,
-					chset_names[ioptr->ochset].len, chset_names[ioptr->ochset].addr);
+					chset_names[io_ptr->ichset].len, chset_names[io_ptr->ichset].addr,
+					chset_names[io_ptr->ochset].len, chset_names[io_ptr->ochset].addr);
 				return FALSE;
 			}
 			if (NULL == (socketptr = iosocket_create(sockaddr, bfsize, is_principal ? file_des : -1, listen_specified)))
 			{
-				REVERT_GTMIO_CH(&ioptr->pair, ch_set);
+				REVERT_GTMIO_CH(&io_ptr->pair, ch_set);
 				return FALSE;
 			}
 			assert((listen_specified == socketptr->passive) || (!listen_specified && is_principal));
@@ -472,7 +476,7 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 					if (FD_INVALID != socketptr->temp_sd)
 						close(socketptr->temp_sd);
 					SOCKET_FREE(socketptr);
-					assert(ioptr->newly_created == FALSE);
+					assert(io_ptr->newly_created == FALSE);
 					rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_SOCKETEXIST, 2, handle_len, sock_handle);
 					return FALSE;
 				}
@@ -487,7 +491,7 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 			/* connects newdsocket and socketptr (the new socket) */
 			if (ydb_max_sockets <= newdsocket->n_socket)
 			{
-				assert(ioptr->newly_created == FALSE);
+				assert(io_ptr->newly_created == FALSE);
 				if (FD_INVALID != socketptr->temp_sd)
 					close(socketptr->temp_sd);
 				SOCKET_FREE(socketptr);
@@ -522,12 +526,12 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 		/* parse the delimiter: delimiter_buffer ==> socketptr->delimiter[...] */
 		if ((0 <= delimiter_len) && (curr_socketptr))
 				iosocket_delimiter(delimiter_buffer, delimiter_len, curr_socketptr, (0 == delimiter_len));
-		if (ioptr->wrap && curr_socketptr && (0 != curr_socketptr->n_delimiter)
-			&& (ioptr->width < curr_socketptr->delimiter[0].len))
+		if (io_ptr->wrap && curr_socketptr && (0 != curr_socketptr->n_delimiter)
+			&& (io_ptr->width < curr_socketptr->delimiter[0].len))
 		{
 			socketptr_delim_len = curr_socketptr->delimiter[0].len;
 			SOCKET_FREE(curr_socketptr);
-			rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_DELIMWIDTH, 2, ioptr->width, socketptr_delim_len);
+			rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_DELIMWIDTH, 2, io_ptr->width, socketptr_delim_len);
 			assert(FALSE);
 		}
 		if (curr_socketptr && (0 <= zff_len) && /* ZFF or ZNOFF specified */
@@ -564,28 +568,28 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 		|| (connect_specified && (!iosocket_connect(socketptr, timepar, ibfsize_specified))))
 	{
 		assert(curr_socketptr == socketptr);	/* since create new socket */
-		REVERT_GTMIO_CH(&ioptr->pair, ch_set);
+		REVERT_GTMIO_CH(&io_ptr->pair, ch_set);
 		return FALSE;
 	} else if (is_principal)
 	{
 		len = SIZEOF(ESTABLISHED) - 1;
-		memcpy(&ioptr->dollar.key[0], ESTABLISHED, len);
-		ioptr->dollar.key[len++] = '|';
+		memcpy(&io_ptr->dollar.key[0], ESTABLISHED, len);
+		io_ptr->dollar.key[len++] = '|';
 		assert((DD_BUFLEN - len - 1) >= socketptr->handle_len); /* handle could be MAX_HANDLE_LEN */
-		memcpy(&ioptr->dollar.key[len], socketptr->handle, MIN(socketptr->handle_len, DD_BUFLEN - len - 2));
+		memcpy(&io_ptr->dollar.key[len], socketptr->handle, MIN(socketptr->handle_len, DD_BUFLEN - len - 2));
 		len += MIN(socketptr->handle_len, DD_BUFLEN - len - 2); /* -2 for the next delimiter and trailing null */
-		ioptr->dollar.key[len++] = '|';
+		io_ptr->dollar.key[len++] = '|';
 		if (socket_tcpip == socketptr->protocol)
-			STRNCPY_STR(&ioptr->dollar.key[len], socketptr->remote.saddr_ip, DD_BUFLEN - len - 1);
+			STRNCPY_STR(&io_ptr->dollar.key[len], socketptr->remote.saddr_ip, DD_BUFLEN - len - 1);
 		else if (socket_local == socketptr->protocol)
 		{
 			if ((NULL != socketptr->local.sa)
 					&& ('\0' != ((struct sockaddr_un *)(socketptr->local.sa))->sun_path[0]))
-				STRNCPY_STR(&ioptr->dollar.key[len], ((struct sockaddr_un *)(socketptr->local.sa))->sun_path,
+				STRNCPY_STR(&io_ptr->dollar.key[len], ((struct sockaddr_un *)(socketptr->local.sa))->sun_path,
 					DD_BUFLEN - len - 1);
 			else if ((NULL != socketptr->remote.sa)
 					&& ('\0' != ((struct sockaddr_un *)(socketptr->remote.sa))->sun_path[0]))
-				STRNCPY_STR(&ioptr->dollar.key[len], ((struct sockaddr_un *)(socketptr->remote.sa))->sun_path,
+				STRNCPY_STR(&io_ptr->dollar.key[len], ((struct sockaddr_un *)(socketptr->remote.sa))->sun_path,
 					DD_BUFLEN - len - 1);
 			/* set default delimiter on principal local sockets to resemble rm device */
 			delimiter_buffer[0] = NATIVE_NL;
@@ -593,37 +597,37 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 			iosocket_delimiter(delimiter_buffer, delimiter_len, socketptr, FALSE);
 		}
 		else
-			ioptr->dollar.key[len] = '\0';
-		ioptr->dollar.key[DD_BUFLEN-1] = '\0';			/* In case we fill the buffer */
+			io_ptr->dollar.key[len] = '\0';
+		io_ptr->dollar.key[DD_BUFLEN-1] = '\0';			/* In case we fill the buffer */
 	}
 	/* commit the changes to the list */
 	if (0 >= dsocketptr->n_socket)		/* before any new socket added */
 	{	/* Set default CHSET in case none supplied */
 		default_chset = (gtm_utf8_mode) ? CHSET_UTF8 : CHSET_M;
-		if (!ichset_specified && !IS_UTF16_CHSET(ioptr->ichset))
-			ioptr->ichset = default_chset;
-		if (!ochset_specified && !IS_UTF16_CHSET(ioptr->ochset))
-			ioptr->ochset = default_chset;
+		if (!ichset_specified && !IS_UTF16_CHSET(io_ptr->ichset))
+			io_ptr->ichset = default_chset;
+		if (!ochset_specified && !IS_UTF16_CHSET(io_ptr->ochset))
+			io_ptr->ochset = default_chset;
 	}
 	/* These parameters are to be set every time CHSET changes */
 	if (ichset_specified)
 	{
-		CHECK_UTF16_VARIANT_AND_SET_CHSET_SOCKET(dsocketptr->ichset_utf16_variant, ioptr->ichset, temp_ichset,
+		CHECK_UTF16_VARIANT_AND_SET_CHSET_SOCKET(dsocketptr->ichset_utf16_variant, io_ptr->ichset, temp_ichset,
 								assert(!socketptr));
 		newdsocket->ichset_utf16_variant = dsocketptr->ichset_utf16_variant;
 		newdsocket->ichset_specified = dsocketptr->ichset_specified = TRUE;
 	}
 	if (ochset_specified)
 	{
-		CHECK_UTF16_VARIANT_AND_SET_CHSET_SOCKET(dsocketptr->ochset_utf16_variant, ioptr->ochset, temp_ochset,
+		CHECK_UTF16_VARIANT_AND_SET_CHSET_SOCKET(dsocketptr->ochset_utf16_variant, io_ptr->ochset, temp_ochset,
 								assert(!socketptr));
 		newdsocket->ochset_utf16_variant = dsocketptr->ochset_utf16_variant;
 		newdsocket->ochset_specified = dsocketptr->ochset_specified = TRUE;
 	}
-	if ((CHSET_M != ioptr->ichset) && (CHSET_UTF16 != ioptr->ichset) && (CHSET_MAX_IDX > ioptr->ichset))
-		get_chset_desc(&chset_names[ioptr->ichset]);
-	if ((CHSET_M != ioptr->ochset) && (CHSET_UTF16 != ioptr->ochset) && (CHSET_MAX_IDX > ioptr->ichset))
-		get_chset_desc(&chset_names[ioptr->ochset]);
+	if ((CHSET_M != io_ptr->ichset) && (CHSET_UTF16 != io_ptr->ichset) && (CHSET_MAX_IDX > io_ptr->ichset))
+		get_chset_desc(&chset_names[io_ptr->ichset]);
+	if ((CHSET_M != io_ptr->ochset) && (CHSET_UTF16 != io_ptr->ochset) && (CHSET_MAX_IDX > io_ptr->ichset))
+		get_chset_desc(&chset_names[io_ptr->ochset]);
 	if (gtm_utf8_mode)
 	{
 		/* If CHSET is being changed to UTF-16, and delimitors are not converted, convert them
@@ -638,10 +642,10 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 				if (!(localsocketptr && (0 < localsocketptr->n_delimiter)))
 					continue;
 				if (((localsocketptr->delimiter[0].addr == localsocketptr->idelimiter[0].addr) &&
-						 IS_UTF16_CHSET(ioptr->ichset) && IS_UTF16_CHSET(dsocketptr->ichset_utf16_variant))
+						 IS_UTF16_CHSET(io_ptr->ichset) && IS_UTF16_CHSET(dsocketptr->ichset_utf16_variant))
 						|| ((localsocketptr->delimiter[0].addr != localsocketptr->idelimiter[0].addr)
-						&& !IS_UTF16_CHSET(ioptr->ichset)))
-					iosocket_idelim_conv(localsocketptr, ioptr->ichset);
+						&& !IS_UTF16_CHSET(io_ptr->ichset)))
+					iosocket_idelim_conv(localsocketptr, io_ptr->ichset);
 			}
 		if (ochset_specified)
 			for (soc_cnt=0; soc_cnt < dsocketptr->n_socket; soc_cnt++)
@@ -650,15 +654,15 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 				if (!(localsocketptr && (0 < localsocketptr->n_delimiter)))
 					continue;
 				if (((localsocketptr->delimiter[0].addr == localsocketptr->odelimiter0.addr) &&
-						IS_UTF16_CHSET(ioptr->ochset) && IS_UTF16_CHSET(dsocketptr->ochset_utf16_variant))
+						IS_UTF16_CHSET(io_ptr->ochset) && IS_UTF16_CHSET(dsocketptr->ochset_utf16_variant))
 						|| ((localsocketptr->delimiter[0].addr != localsocketptr->odelimiter0.addr)
-						&& !IS_UTF16_CHSET(ioptr->ochset)))
-					iosocket_odelim_conv(localsocketptr, ioptr->ochset);
+						&& !IS_UTF16_CHSET(io_ptr->ochset)))
+					iosocket_odelim_conv(localsocketptr, io_ptr->ochset);
 			}
 		/* Now convert the ZFFs */
 		if (ochset_specified)
 		{
-			if (!IS_UTF16_CHSET(ioptr->ochset))
+			if (!IS_UTF16_CHSET(io_ptr->ochset))
 			{	/* Changed to a non-UTF16 CHSET. free all converted ZFFs */
 				for (soc_cnt=0; soc_cnt < dsocketptr->n_socket; soc_cnt++)
 				{
@@ -678,7 +682,7 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 						 && (localsocketptr->ozff.addr == localsocketptr->zff.addr))
 					{
 						conv_len = MAX_ZFF_LEN;
-						new_ozff_len = gtm_conv(chset_desc[CHSET_UTF8], chset_desc[ioptr->ochset],
+						new_ozff_len = gtm_conv(chset_desc[CHSET_UTF8], chset_desc[io_ptr->ochset],
 							&localsocketptr->zff, conv_buff, &conv_len);
 						assert(MAX_ZFF_LEN > new_ozff_len);
 						localsocketptr->ozff.len = new_ozff_len;
@@ -695,8 +699,8 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, uint
 		socketptr->dev = dsocketptr;
 		memcpy(dsocketptr, newdsocket, d_socket_struct_len);
 	}
-	ioptr->newly_created = FALSE;
-	ioptr->state = dev_open;
-	REVERT_GTMIO_CH(&ioptr->pair, ch_set);
+	io_ptr->newly_created = FALSE;
+	io_ptr->state = dev_open;
+	REVERT_GTMIO_CH(&io_ptr->pair, ch_set);
 	return TRUE;
 }

--- a/sr_port/iosocket_use.c
+++ b/sr_port/iosocket_use.c
@@ -277,7 +277,8 @@ void	iosocket_use(io_desc *iod, mval *pp)
 				if (DEFAULT_CODE_SET != iod->in_code_set)
 					ICONV_OPEN_CD(iod->input_conv_cd, INSIDE_CH_SET, (char *)(pp->str.addr + p_offset + 1));
 #				endif
-				GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				//kt original --> GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				GET_ADDR_AND_LEN(pp, p_offset, chset_mstr.addr, chset_mstr.len);  //kt 
 				SET_ENCODING(temp_ichset, &chset_mstr);
 				if (!gtm_utf8_mode && IS_UTF_CHSET(temp_ichset))
 					break;	/* ignore UTF chsets if not utf8_mode */
@@ -293,7 +294,8 @@ void	iosocket_use(io_desc *iod, mval *pp)
 				if (DEFAULT_CODE_SET != iod->out_code_set)
 					ICONV_OPEN_CD(iod->output_conv_cd, (char *)(pp->str.addr + p_offset + 1), INSIDE_CH_SET);
 #				endif
-				GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				//kt original --> GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				GET_ADDR_AND_LEN(pp, p_offset, chset_mstr.addr, chset_mstr.len);  //kt
 				SET_ENCODING(temp_ochset, &chset_mstr);
 				if (!gtm_utf8_mode && IS_UTF_CHSET(temp_ochset))
 					break;	/* ignore UTF chsets if not utf8_mode */
@@ -302,7 +304,8 @@ void	iosocket_use(io_desc *iod, mval *pp)
 				break;
 			case iop_chset:
 				n_specified_dev++;
-				GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				//kt original --> GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				GET_ADDR_AND_LEN(pp, p_offset, chset_mstr.addr, chset_mstr.len);  //kt 
 				SET_ENCODING(temp_ochset, &chset_mstr);
 				SET_ENCODING(temp_ichset, &chset_mstr);
 				if (!gtm_utf8_mode && IS_UTF_CHSET(temp_ichset))

--- a/sr_port/op_use.c
+++ b/sr_port/op_use.c
@@ -110,7 +110,7 @@ void op_use(mval *v, mval *p)
 	io_curr_device = nl->iod->pair;
 	io_curr_device.in->name = nl;
 	if (nl->iod->pair.in == nl->iod->pair.out)
-		(nl->iod->disp_ptr->use)(nl->iod, p);
+		(nl->iod->disp_ptr->use)(nl->iod, p);  //kt doc:  call use()
 	else
 	{
 		if (2 != dollar_zpselect)

--- a/sr_unix/iorm_use.c
+++ b/sr_unix/iorm_use.c
@@ -102,11 +102,14 @@
 	ADDR = (char *)(pp->str.addr + p_offset + 1);
 
 /* Obtain the key and IV from the KEY field, which is expected to be in the format <key><space><iv>, where iv is optional. */
-#define GET_KEY_AND_IV(DIRECTION)									\
+//kt CHANGED:	from 	GET_ADDR_AND_LEN(DIRECTION ## _key.addr, DIRECTION ## _key.len);
+//    		to 	GET_ADDR_AND_LEN(STRUCT, OFFSET, DIRECTION ## _key.addr, DIRECTION ## _key.len);
+//   Purpose of change" remove dependance on local scope
+#define GET_KEY_AND_IV(STRUCT, OFFSET, DIRECTION)									\
 {													\
 	int i, len, encr_key_delim_pos;									\
 													\
-	GET_ADDR_AND_LEN(DIRECTION ## _key.addr, DIRECTION ## _key.len);				\
+	GET_ADDR_AND_LEN(STRUCT, OFFSET, DIRECTION ## _key.addr, DIRECTION ## _key.len);				\
 	for (i = 0, encr_key_delim_pos = len = DIRECTION ## _key.len; i < DIRECTION ## _key.len; i++)	\
 	{												\
 		if (ENCR_KEY_DELIM_CHAR == *((char *)DIRECTION ## _key.addr + i))			\
@@ -612,7 +615,8 @@ void	iorm_use(io_desc *iod, mval *pp)
 #			endif
 			if (chset_allowed)
 			{
-				GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				//kt original --> GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				GET_ADDR_AND_LEN(pp, p_offset, chset_mstr.addr, chset_mstr.len);
 				SET_ENCODING(temp_chset, &chset_mstr);
 				if (!gtm_utf8_mode && IS_UTF_CHSET(temp_chset))
 					break;	/* ignore UTF chsets if not utf8_mode */
@@ -634,7 +638,8 @@ void	iorm_use(io_desc *iod, mval *pp)
 #			endif
 			if (chset_allowed)
 			{
-				GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				//kt original --> GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				GET_ADDR_AND_LEN(pp, p_offset, chset_mstr.addr, chset_mstr.len);
 				SET_ENCODING(temp_chset, &chset_mstr);
 				if (!gtm_utf8_mode && IS_UTF_CHSET(temp_chset))
 					break;	/* ignore UTF chsets if not utf8_mode */
@@ -649,7 +654,8 @@ void	iorm_use(io_desc *iod, mval *pp)
 		{
 			if (chset_allowed)
 			{
-				GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				//kt original --> GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+				GET_ADDR_AND_LEN(pp, p_offset, chset_mstr.addr, chset_mstr.len);
 				SET_ENCODING(temp_chset, &chset_mstr);
 				if (!gtm_utf8_mode && IS_UTF_CHSET(temp_chset))
 					break;	/* ignore UTF chsets if not utf8_mode */
@@ -873,11 +879,11 @@ void	iorm_use(io_desc *iod, mval *pp)
 			break;
 		case iop_key:			/* CAUTION: fall-through */
 		case iop_input_key:
-			GET_KEY_AND_IV(input);
+			GET_KEY_AND_IV(pp, p_offset, input);  //kt mod
 			if (iop_key != c)	/* CAUTION: potential fall-through */
 				break;
 		case iop_output_key:
-			GET_KEY_AND_IV(output);
+			GET_KEY_AND_IV(pp, p_offset, output);  //kt mod
 			break;
 		case iop_buffered:
 			if (rm_ptr->fifo || rm_ptr->is_pipe)

--- a/sr_unix/iott_close.c
+++ b/sr_unix/iott_close.c
@@ -54,6 +54,7 @@ void iott_close(io_desc *v, mval *pp)
 	assert((v->pair.in == v) || (v->pair.out == v));
 	ttptr = (d_tt_struct *)v->dev_sp;
 	v->state = dev_closed;
+	((d_tt_struct *)v->dev_sp)->setterm_done_by = process_id;  //kt added.  Set flag to ensure resetterm is actually done
 	iott_resetterm(v);
 
 	p_offset = 0;

--- a/sr_unix/iott_open.c
+++ b/sr_unix/iott_open.c
@@ -21,6 +21,7 @@
 #include "gtm_string.h"
 #include "gtm_stdlib.h"
 #include "gtm_termios.h"
+#include "gtm_threadgbl.h"  					//kt added
 
 #include "io.h"
 #include "iottdef.h"
@@ -37,12 +38,15 @@
 #include "op.h"
 #include "indir_enum.h"
 #include "ydb_getenv.h"
+#include "deferred_events_queue.h"  				//kt added
 
 GBLREF int		COLUMNS, GTM_LINES, AUTO_RIGHT_MARGIN;
 GBLREF uint4		ydb_principal_editing_defaults;
-GBLREF io_pair		io_std_device;
+GBLREF io_pair		io_std_device, io_curr_device;		//kt added io_curr_device
 GBLREF	boolean_t	gtm_utf8_mode;
 LITREF unsigned char	io_params_size[];
+GBLREF boolean_t	ctrlc_on, hup_on;			//kt added line
+GBLREF io_termmask 	NULL_TERM_MASK;  			//kt added
 
 error_def(ERR_BADCHSET);
 error_def(ERR_NOTERMENTRY);
@@ -51,11 +55,21 @@ error_def(ERR_NOTERMINFODB);
 error_def(ERR_TCGETATTR);
 error_def(ERR_ZINTRECURSEIO);
 
-short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 timeout)
+short iott_open(io_log_name * dev_name, mval * devparms, int fd, mval * mspace, uint8 timeout)
+/*
+//kt documentation
+INPUT:
+  dev_name:  ptr to logical name structure
+  devparms:  ptr to device params
+  fd:        int file descriptor, to pass to file system
+  mspace:    pt to ?? purpose struct.  May be NULL
+  timeout:   timeout val.
+*/
+//kt NOTE: renamed variable "pp" -> "devparms", here and many spots below.  Each change was not marked, so search for devparms for location of changes.
 {
 	unsigned char	ch;
 	d_tt_struct	*tt_ptr;
-	io_desc		*ioptr;
+	io_desc		*io_ptr;   //kt renamed ioptr to io_ptr for consistency across codebase.  Changes below not marked.  Just search for io_ptr
 	int		status, chset_index;
 	int		save_errno;
 	int		p_offset;
@@ -63,92 +77,50 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 	gtm_chset_t	temp_chset, old_ichset;
 	boolean_t	empt = FALSE;
 	boolean_t	ch_set;
+	boolean_t	initializing = FALSE; 		//kt added
 	DCL_THREADGBL_ACCESS;
 
 	SETUP_THREADGBL_ACCESS;
-	ioptr = dev_name->iod;
-	ESTABLISH_RET_GTMIO_CH(&ioptr->pair, -1, ch_set);
-	if (ioptr->state == dev_never_opened)
+	io_ptr = dev_name->iod;
+	ESTABLISH_RET_GTMIO_CH(&io_ptr->pair, -1, ch_set);
+	if (io_ptr->state == dev_never_opened)
 	{
-		dev_name->iod->dev_sp = (void *)malloc(SIZEOF(d_tt_struct) + SIZEOF(struct termios));
-		memset(dev_name->iod->dev_sp, 0, SIZEOF(d_tt_struct) + SIZEOF(struct termios));
+		//kt Large block change.  Putting state into separate structure, which is not a pointer....
+		//NOTE: I have changed d_tt_struct such that additional memory does not need to be allocated for ttio_struct's
+		dev_name->iod->dev_sp = (void *)malloc(SIZEOF(d_tt_struct));
+		memset(dev_name->iod->dev_sp, 0, SIZEOF(d_tt_struct)); // NOTE: by filling structure initially with 0's, this effects setting all booleans to FALSE. E.g. tt_ptr->io_state.canonical etc.
 		tt_ptr = (d_tt_struct *)dev_name->iod->dev_sp;
-		tt_ptr->ttio_struct = (struct termios *)((char *)tt_ptr + SIZEOF(d_tt_struct));
 		tt_ptr->in_buf_sz = TTDEF_BUF_SZ;
 		tt_ptr->enbld_outofbands.x = 0;
-		tt_ptr->term_ctrl &= (~TRM_NOECHO);
 		tt_ptr->ttybuff = (char *)malloc(IOTT_BUFF_LEN);
-		tt_ptr->default_mask_term = TRUE;
-		ioptr->ichset = ioptr->ochset = gtm_utf8_mode ? CHSET_UTF8 : CHSET_M;	/* default */
+		io_ptr->ichset = io_ptr->ochset = gtm_utf8_mode ? CHSET_UTF8 : CHSET_M;	/* default */
+
+		//Initialize ydb IO state based on current state of TTY IO subsystem.
+		//loads TTY IO into tt_ptr->initial_io_state -- will later be used to restore terminal to initial state when exiting program
+		iott_TTY_to_state(tt_ptr, &(tt_ptr->initial_io_state));
+
+		initializing = TRUE;  //set up direct mode io state at the end of this function, after terminators etc initialized.
+
+		//Start setup of device, starting io_state from initial_io_state
+		//Will be further modified below.
+		tt_ptr->io_state = tt_ptr->initial_io_state;
+
+		//kt end mod -------------
 	}
 	tt_ptr = (d_tt_struct *)dev_name->iod->dev_sp;
 	if (tt_ptr->mupintr)
 		RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(1) ERR_ZINTRECURSEIO);
 	p_offset = 0;
-	old_ichset = ioptr->ichset;
-	while (*(pp->str.addr + p_offset) != iop_eol)
-	{
-		switch (ch = *(pp->str.addr + p_offset++))
-		{
-		case iop_exception:
-			DEF_EXCEPTION(pp, p_offset, ioptr);
-			break;
-		case iop_canonical:
-			tt_ptr->canonical = TRUE;
-			break;
-		case iop_nocanonical:
-			tt_ptr->canonical = FALSE;
-			break;
-		case iop_empterm:
-			empt = TRUE;
-			break;
-		case iop_noempterm:
-			empt = FALSE;
-			break;
-		case iop_m:
-			ioptr->ichset = ioptr->ochset = CHSET_M;
-			break;
-		case iop_utf8:
-			if (gtm_utf8_mode)
-				ioptr->ichset = ioptr->ochset = CHSET_UTF8;
-			break;
-		case iop_ipchset:
-		case iop_opchset:
-		case iop_chset:
-			if (gtm_utf8_mode)
-			{
-				GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
-				SET_ENCODING(temp_chset, &chset_mstr);
-				if (IS_UTF16_CHSET(temp_chset)) /* Not allowed for terminals */
-					RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_BADCHSET, 2, chset_mstr.len, chset_mstr.addr);
-					else if (ch == iop_ipchset)
-						ioptr->ichset = temp_chset;
-					else if (ch == iop_opchset)
-						ioptr->ochset = temp_chset;
-					else if (ch == iop_chset)
-					{
-						ioptr->ichset = temp_chset;
-						ioptr->ochset = temp_chset;
-					}
-			}
-			break;
-		}
-		UPDATE_P_OFFSET(p_offset, ch, pp);	/* updates "p_offset" using "ch" and "pp" */
-	}
-	if (ioptr->state != dev_open)
+	old_ichset = io_ptr->ichset;
+	iott_open_params_to_state(io_ptr, devparms, &(tt_ptr->io_state));  //kt added moving prior block
+	if (io_ptr->state != dev_open)
 	{
 		int	status;
 		char	*env_term;
 
 		assert(fd >= 0);
 		tt_ptr->fildes = fd;
-		status = tcgetattr(tt_ptr->fildes, tt_ptr->ttio_struct);
-		if (0 != status)
-		{
-			save_errno = errno;
-			if (gtm_isanlp(tt_ptr->fildes) == 0)
-				RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCGETATTR, 1, tt_ptr->fildes, save_errno);
-		}
+		//kt removed block.  In iott_compile_state_and_set_tty_and_ydb_echo(), below, tt_ptr->io_state.ttio_struct will be properly set up.
 		status = getcaps(tt_ptr->fildes);
 		if (1 != status)
 		{
@@ -164,48 +136,134 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 			} else
 				rts_error_csa(CSA_ARG(NULL) VARLSTCNT(1) ERR_NOTERMINFODB);
 		}
-		ioptr->width = COLUMNS;
-		ioptr->length = GTM_LINES;
-		ioptr->wrap = (0 == AUTO_RIGHT_MARGIN) ? FALSE : TRUE; /* defensive programming; till we are absolutely, positively
+		io_ptr->width = COLUMNS;
+		io_ptr->length = GTM_LINES;
+		io_ptr->wrap = (0 == AUTO_RIGHT_MARGIN) ? FALSE : TRUE; /* defensive programming; till we are absolutely, positively
 									* certain that there are no uses of wrap == TRUE */
 		tt_ptr->tbuffp = tt_ptr->ttybuff;	/* Buffer is now empty */
-		tt_ptr->discard_lf = FALSE;
-		if (!io_std_device.in || io_std_device.in == ioptr->pair.in)	/* io_std_device.in not set yet in io_init */
+		tt_ptr->io_state.discard_lf = FALSE;
+		if (!io_std_device.in || io_std_device.in == io_ptr->pair.in)	/* io_std_device.in not set yet in io_init */
 		{	/* $PRINCIPAL */
-			tt_ptr->ext_cap = ydb_principal_editing_defaults;
-			ioptr->ichset = ioptr->ochset = gtm_utf8_mode ? CHSET_UTF8 : CHSET_M;	/* default */
+			tt_ptr->io_state.ext_cap = ydb_principal_editing_defaults;
+			io_ptr->ichset = io_ptr->ochset = gtm_utf8_mode ? CHSET_UTF8 : CHSET_M;	/* default */
 		} else
-			tt_ptr->ext_cap = 0;
+			tt_ptr->io_state.ext_cap = 0;
 		if (empt)
-			tt_ptr->ext_cap |= TT_EMPTERM;
+			SET_BIT_FLAG_ON(TT_EMPTERM, tt_ptr->io_state.ext_cap); //kt mod
 		/* Set terminal mask on the terminal not open, if default_term or if CHSET changes */
-		if (tt_ptr->default_mask_term || (old_ichset != ioptr->ichset))
+		if (tt_ptr->io_state.default_mask_term || (old_ichset != io_ptr->ichset))
 		{
-			memset(&tt_ptr->mask_term.mask[0], 0, SIZEOF(io_termmask));
-			if (CHSET_M != ioptr->ichset)
-			{
-				tt_ptr->mask_term.mask[0] = TERM_MSK_UTF8_0;
-				tt_ptr->mask_term.mask[4] = TERM_MSK_UTF8_4;
-			} else
-				tt_ptr->mask_term.mask[0] = TERM_MSK;
-			tt_ptr->default_mask_term = TRUE;
+			set_mask_term_conditional(io_ptr, &(tt_ptr->io_state.mask_term), (CHSET_M != io_ptr->ichset), TRUE);  //kt mod combining duplicate code
 		}
-		ioptr->state = dev_open;
+		io_ptr->state = dev_open;
 	} else
 	{
-		/* Set terminal mask on the already open terminal, if CHSET changes */
-		if (old_ichset != ioptr->ichset)
+		// Set terminal mask on the already open terminal, if CHSET changes
+		if (old_ichset != io_ptr->ichset)
 		{
-			memset(&tt_ptr->mask_term.mask[0], 0, SIZEOF(io_termmask));
-			if (CHSET_M != ioptr->ichset)
-			{
-				tt_ptr->mask_term.mask[0] = TERM_MSK_UTF8_0;
-				tt_ptr->mask_term.mask[4] = TERM_MSK_UTF8_4;
-			} else
-				tt_ptr->mask_term.mask[0] = TERM_MSK;
-			tt_ptr->default_mask_term = TRUE;
+			set_mask_term_conditional(io_ptr, &(tt_ptr->io_state.mask_term), (CHSET_M != io_ptr->ichset), TRUE);  //kt mod combining duplicate code
 		}
 	}
-	REVERT_GTMIO_CH(&ioptr->pair, ch_set);
+
+	//kt Compile ydb state and send this to TTY IO subsystem.  8  1 will be default time, min_read; can be changed later.
+	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, SET_TTY_CHECK_ERRORS_MODE_3);  //kt added.
+	if (initializing)  //kt added block
+	{
+		//complete setup for initial io state.
+		set_mask_term_conditional(io_ptr, &(tt_ptr->initial_io_state.mask_term), (CHSET_M != io_ptr->ichset), TRUE);
+
+		//setup an IO state for use when interacting with user at console in direct mode.
+		tt_ptr->direct_mode_io_state = tt_ptr->io_state;
+		tt_ptr->direct_mode_io_state.canonical = FALSE;
+		tt_ptr->direct_mode_io_state.devparam_echo = TRUE;
+		iott_compile_ttio_struct(io_ptr,  &(tt_ptr->direct_mode_io_state), 8, 1);   //compiles IO state into direct_mode_io_state.ttio_struct
+
+	}
+	REVERT_GTMIO_CH(&io_ptr->pair, ch_set);
 	return TRUE;
+}
+
+void iott_TTY_to_state(d_tt_struct * tt_ptr, ttio_state* an_io_state_ptr)
+//kt added function
+//Purpose: Set ydb IO state based on state of TTY IO subsystem, esp when first opening TTY IO device.
+//
+//  Why needed? Because if the TTY IO initially has echo (+) mode but no devparam specifies state of echo,
+//  then ydb would leave state in default value (all 0's --> false).  Thus ydb state would not be
+//  synchronized with actual TTY IO subsystem.  So will set ydb state from TTY IO first, then later
+//  let ydb change anything wanted based on devparams.
+//
+//  Update: The code has been extended so that echo mode or noecho mode is specified as a devparam, but
+//	    I will leave this code in because the principle of starting with the state of the TTY system
+//	    still holds.
+//
+{
+	int		status;
+	struct termios	cur_IO_state;
+	int		save_errno;
+
+	status = tcgetattr(tt_ptr->fildes, &cur_IO_state);
+	if (0 != status)
+	{
+		save_errno = errno;
+		if (gtm_isanlp(tt_ptr->fildes) == 0)
+			RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCGETATTR, 1, tt_ptr->fildes, save_errno);
+	}
+	//kt printf("debug point 1 in iott_TTY_to_state() in iott_open.c  Echo value: %d\n", BIT_FLAG_IS_ON (0010, cur_IO_state.c_lflag));  // ECHO   (0010): 000000001000 Enable echo.
+
+	tio_struct_to_state(an_io_state_ptr, &cur_IO_state);
+}
+
+void tio_struct_to_state(ttio_state* an_io_state_ptr, struct termios * ttio_struct_ptr)
+//kt added function
+//Purpose: Set ydb IO state based on value of a ttio_struct_ptr
+{
+	an_io_state_ptr->ttio_struct = *ttio_struct_ptr;
+
+	an_io_state_ptr->ttsync         = BIT_FLAG_IS_ON(IXON,   ttio_struct_ptr->c_iflag); //note "i" flag e.g. "I"
+	an_io_state_ptr->hostsync       = BIT_FLAG_IS_ON(IXOFF,  ttio_struct_ptr->c_iflag); //note "i" flag e.g. "I"
+	an_io_state_ptr->canonical      = BIT_FLAG_IS_ON(ICANON, ttio_struct_ptr->c_lflag); //note "l" flag e.g. "L"  <-- different
+	an_io_state_ptr->devparam_echo  = BIT_FLAG_IS_ON(ECHO,   ttio_struct_ptr->c_lflag); //note "l" flag e.g. "L"  <-- different
+
+	an_io_state_ptr->default_mask_term = TRUE;
+}
+
+void iott_open_params_to_state(io_desc* io_ptr, mval* devparms, ttio_state* io_state_ptr)
+//kt added function
+//kt NOTE: This establishes the IO state into ydb data structures, based on USE device parameters.
+//	   It does NOT write anything out to the TTY IO subsystem.
+{
+	d_tt_struct* 		tt_ptr;
+	DCL_THREADGBL_ACCESS;
+
+	SETUP_THREADGBL_ACCESS;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+	if (tt_ptr->mupintr)
+		RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(1) ERR_ZINTRECURSEIO);
+	iott_common_params_to_state(io_ptr, io_state_ptr, devparms, is_valid_open_param);
+}
+
+boolean_t is_valid_open_param(io_params_type aparam)   //is aparam valid for OPEN command?
+//kt added function
+{
+	boolean_t	result;
+	result = (	(aparam == iop_exception) 	||
+			(aparam == iop_echo) 		||
+			(aparam == iop_noecho) 		||
+			(aparam == iop_canonical) 	||
+			(aparam == iop_nocanonical)	||
+			(aparam == iop_empterm)		||
+			(aparam == iop_noempterm)	||
+			(aparam == iop_m)		||
+			(aparam == iop_utf8)		||
+			(aparam == iop_ipchset)		||
+			(aparam == iop_opchset)		||
+			(aparam == iop_chset) 		||
+			//---- below are sometimes added to devparams in io_init, but apparently not processed.
+			(aparam == iop_newversion)	||
+			(aparam == iop_stream)		||
+			(aparam == iop_nl)		||
+			(aparam == iop_shared)		||
+			(aparam == iop_readonly)		);
+
+	return result;
 }

--- a/sr_unix/iott_readfl.c
+++ b/sr_unix/iott_readfl.c
@@ -21,6 +21,8 @@
 #include "gtm_string.h"
 #include "gtm_poll.h"
 #include "gtm_stdlib.h"
+#include "gtm_signal.h"	/* for SIGPROCMASK used inside Tcsetattr */  //kt added
+#include "gtm_isanlp.h"  //kt added
 
 #include "io_params.h"
 #include "io.h"
@@ -88,14 +90,17 @@ error_def(ERR_NOPRINCIO);
 error_def(ERR_TERMHANGUP);
 error_def(ERR_ZINTRECURSEIO);
 
-#define IOTT_MOVE_START_OF_LINE(TT_PTR_FILDES, DX, DX_INSTR, DX_START, IOPTR_WIDTH, MASK, TERM_ERROR_LINE, INSTR)	\
+//kt original --> #define IOTT_MOVE_START_OF_LINE(TT_PTR_FILDES, DX, DX_INSTR, DX_START, IOPTR_WIDTH, MASK, TERM_ERROR_LINE, INSTR)
+//kt  Also, changed if (!(mask & TRM_NOECHO)) -->  if (ECHO_MODE)
+
+#define IOTT_MOVE_START_OF_LINE(TT_PTR_FILDES, ECHO_MODE, DX, DX_INSTR, DX_START, IOPTR_WIDTH, TERM_ERROR_LINE, INSTR)	\
 MBSTART {														\
 	int	num_lines_above;											\
 	int	num_chars_left;												\
 															\
 	num_lines_above = (dx_instr + dx_start) / ioptr_width;								\
 	num_chars_left = dx - dx_start;											\
-	if (!(mask & TRM_NOECHO))											\
+	if (ECHO_MODE)													\
 	{														\
 		if (0 != move_cursor(tt_ptr->fildes, num_lines_above, num_chars_left))					\
 		{													\
@@ -107,7 +112,9 @@ MBSTART {														\
 	dx = dx_start;													\
 } MBEND
 
-#define IOTT_MOVE_END_OF_LINE(TT_PTR_FILDES, DX, DX_INSTR, DX_START, DX_OUTLEN, IOPTR_WIDTH, MASK, TERM_ERROR_LINE, INSTR, OUTLEN)	\
+//kt original --> #define IOTT_MOVE_END_OF_LINE(TT_PTR_FILDES, DX, DX_INSTR, DX_START, DX_OUTLEN, IOPTR_WIDTH, MASK, TERM_ERROR_LINE, INSTR, OUTLEN)
+//kt Also, changed if (!(mask & TRM_NOECHO)) -->  if (ECHO_MODE)
+#define IOTT_MOVE_END_OF_LINE(TT_PTR_FILDES, ECHO_MODE, DX, DX_INSTR, DX_START, DX_OUTLEN, IOPTR_WIDTH, TERM_ERROR_LINE, INSTR, OUTLEN)	\
 MBSTART {																\
 	int	num_lines_above;													\
 	int	num_chars_left;														\
@@ -124,7 +131,7 @@ MBSTART {																\
 	else																\
 		num_chars_left = - ((dx_outlen + dx_start) % ioptr_width);								\
 																	\
-	if (!(mask & TRM_NOECHO))													\
+	if (ECHO_MODE)															\
 	{																\
 		if (0 != move_cursor(tt_ptr->fildes, num_lines_above, num_chars_left))							\
 		{															\
@@ -210,7 +217,12 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 	io_termmask	mask_term;
 	mv_stent	*mvc, *mv_zintdev;
 	tt_interrupt	*tt_state;
-	uint4		mask;
+	//kt removed --> uint4		mask;
+	boolean_t	echo_mode;  		//kt added
+	uint4		ext_cap;  		//kt added
+	ttio_state	temp_io_state; 		//kt added
+	boolean_t	char_is_terminator;	//kt added
+	boolean_t	char_is_special_terminator; //kt added
 	unsigned char	inbyte, *outptr, *outtop, *zb_ptr, *zb_top;
 	unsigned char	more_buf[GTM_MB_LEN_MAX + 1], *more_ptr;	/* to build up multi byte for character */
 	unsigned char	*buffer_start;		/* beginning of non UTF8 buffer */
@@ -236,11 +248,25 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 	}
 	ESTABLISH_RET_GTMIO_CH(&io_curr_device, -1, ch_set);
 	tt_ptr = (d_tt_struct *)(io_ptr->dev_sp);
-	SETTERM_IF_NEEDED(io_ptr, tt_ptr);
+	//kt original --> SETTERM_IF_NEEDED(io_ptr, tt_ptr);
+	if ((length != tt_ptr->in_buf_sz) && (tt_ptr->io_state.canonical == true))   //kt added block
+	{
+		//Handle situation: READ X#123  <-- i.e. read particular number of characters.
+		//NOTE: Canonical is not compatible with reading a particular number of characters, because TTY IO subsystem will hold on to all chars until a terminator (e.g. LF or CR) encountered
+		iott_setterm_for_no_canonical(io_ptr, &temp_io_state);	//kt added.  Establishes temp_io_state for use here in this function
+	} else
+	{
+		SETTERM_IF_NEEDED(io_ptr, tt_ptr);
+		temp_io_state = tt_ptr->io_state;  		//kt make temp_io_state to be same as normal state.
+	}
 	assert(dev_open == io_ptr->state);
 	iott_flush(io_curr_device.out);
-	insert_mode = !(TT_NOINSERT & tt_ptr->ext_cap);	/* get initial mode */
-	empterm	= (TT_EMPTERM & tt_ptr->ext_cap);
+	ext_cap =  temp_io_state.ext_cap; 			//kt added
+	//kt original --> insert_mode = !(TT_NOINSERT & temp_io_state.ext_cap);	/* get initial mode */  //kt mod  Added 'temp_io_state.'
+	insert_mode = BIT_FLAG_IS_OFF(TT_NOINSERT, ext_cap);	/* get initial mode */  		//kt mod
+	//kt original --> empterm	= (TT_EMPTERM & temp_io_state.ext_cap);				//kt mod  Added 'temp_io_state.'
+	empterm	= BIT_FLAG_IS_ON(TT_EMPTERM, ext_cap); 							//kt mod
+	echo_mode = temp_io_state.ydb_echo; 								//kt added for convenience
 	ioptr_width = io_ptr->width;
 	utf8_active = gtm_utf8_mode ? (CHSET_M != io_ptr->ichset) : FALSE;
 	/* if utf8_active, need room for multi byte characters plus wint_t buffer */
@@ -345,15 +371,18 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 	}
 	v->str.len = 0;
 	ret = TRUE;
-	mask = tt_ptr->term_ctrl;
-	mask_term = tt_ptr->mask_term;
+	//kt removed --> mask = temp_io_state.term_ctrl;
+	mask_term = temp_io_state.mask_term;						//kt mod  Added 'temp_io_state.'
 	/* keep test in next line in sync with test in iott_rdone.c */
-	edit_mode = (0 != (TT_EDITING & tt_ptr->ext_cap) && !((TRM_NOECHO|TRM_PASTHRU) & mask));
+	//kt original --> edit_mode = (0 != (TT_EDITING & temp_io_state.ext_cap) && !((TRM_NOECHO|TRM_PASTHRU) & mask));	//kt mod  Added 'temp_io_state.'
+	edit_mode = ( BIT_FLAG_IS_ON(TT_EDITING, ext_cap) && (temp_io_state.passthru == FALSE ) && echo_mode );  		//kt mod
 	if (!zint_restart)
 	{
-		if (mask & TRM_NOTYPEAHD)
+		//kt original --> if (mask & TRM_NOTYPEAHD)
+		if (temp_io_state.no_type_ahead)  					//kt mod
 			TCFLUSH(tt_ptr->fildes, TCIFLUSH, status);
-		if (mask & TRM_READSYNC)
+		//kt original --> if (mask & TRM_READSYNC)
+		if (temp_io_state.readsync)  						//kt mod
 		{
 			DOWRITERC(tt_ptr->fildes, &dc1, 1, status);
 			if (0 != status)
@@ -365,6 +394,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 	}
 	if (edit_mode)
 	{	/* remove ESC and editing control characters from terminator list */
+		/*
 		mask_term.mask[ESC / NUM_BITS_IN_INT4] &= ~(1 << ESC);
 		mask_term.mask[EDIT_SOL / NUM_BITS_IN_INT4] &= ~(1 << EDIT_SOL);
 		mask_term.mask[EDIT_EOL / NUM_BITS_IN_INT4] &= ~(1 << EDIT_EOL);
@@ -373,6 +403,17 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 		mask_term.mask[EDIT_LEFT / NUM_BITS_IN_INT4] &= ~(1 << EDIT_LEFT);
 		mask_term.mask[EDIT_RIGHT / NUM_BITS_IN_INT4] &= ~(1 << EDIT_RIGHT);
 		mask_term.mask[EDIT_ERASE / NUM_BITS_IN_INT4] &= ~(1 << EDIT_ERASE);
+		*/
+		//kt mod below using bit mask macro
+		TURN_MASK_BIT_OFF(mask_term.mask, ESC);
+		TURN_MASK_BIT_OFF(mask_term.mask, EDIT_SOL);
+		TURN_MASK_BIT_OFF(mask_term.mask, EDIT_EOL);
+		TURN_MASK_BIT_OFF(mask_term.mask, EDIT_DEOL);
+		TURN_MASK_BIT_OFF(mask_term.mask, EDIT_DELETE);
+		TURN_MASK_BIT_OFF(mask_term.mask, EDIT_LEFT);
+		TURN_MASK_BIT_OFF(mask_term.mask, EDIT_RIGHT);
+		TURN_MASK_BIT_OFF(mask_term.mask, EDIT_ERASE);
+
 		if (!zint_restart)
 		{
 			/* to turn keypad on if possible */
@@ -504,7 +545,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 			HANDLE_EINTR_OUTSIDE_SYSTEM_CALL;
 			/* set prin_in_dev_failure to FALSE to indicate input device is working now */
 			prin_in_dev_failure = FALSE;
-			if (tt_ptr->canonical)
+			if (temp_io_state.canonical)  //kt mod  Added 'temp_io_state.'
 			{
 				if (0 == inbyte)
 				{
@@ -516,7 +557,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 					io_ptr->dollar.x = 0;
 					io_ptr->dollar.za = ZA_IO_ERR;
 					io_ptr->dollar.y++;
-					tt_ptr->discard_lf = FALSE;
+					temp_io_state.discard_lf = FALSE; 		 //kt mod  Added 'temp_io_state.'
 					if (io_ptr->error_handler.len > 0)
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(1) ERR_IOEOF);
 					break;
@@ -526,9 +567,9 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 #ifdef UTF8_SUPPORTED
 			if (utf8_active)
 			{
-				if (tt_ptr->discard_lf)
+				if (temp_io_state.discard_lf)  				//kt mod  Added 'temp_io_state.'
 				{	/* saw CR last time so ignore following LF */
-					tt_ptr->discard_lf = FALSE;
+					temp_io_state.discard_lf = FALSE; 		 //kt mod  Added 'temp_io_state.'
 					if (NATIVE_LF == inbyte)
 						continue;
 				}
@@ -590,13 +631,15 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 					if (BOM_CODEPOINT == inchar)
 						continue;
 				}
-				if (mask & TRM_CONVERT)
+				//kt original --> if (mask & TRM_CONVERT)
+				if (temp_io_state.case_convert)  		//kt mod, using .case_convert to hold state.
 					inchar = u_toupper(inchar);
 				GTM_IO_WCWIDTH(inchar, inchar_width);
 			} else
 			{
 #endif
-				if (mask & TRM_CONVERT)
+				//kt original --> if (mask & TRM_CONVERT)
+				if (temp_io_state.case_convert)  		//kt mod, using .case_convert to hold state.
 					NATIVE_CVT2UPPER(inbyte, inbyte);
 				inchar = inbyte;
 				inchar_width = 1;
@@ -604,7 +647,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 			}
 #endif
 			GETASCII(asc_inchar,inchar);
-			if (!edit_mode && (dx >= ioptr_width) && io_ptr->wrap && !(mask & TRM_NOECHO))
+			//kt original --> if (!edit_mode && (dx >= ioptr_width) && io_ptr->wrap && !(mask & TRM_NOECHO))
+			if ( !edit_mode && (dx >= ioptr_width) && io_ptr->wrap && echo_mode )  //kt mod
 			{
 				DOWRITE(tt_ptr->fildes, NATIVE_TTEOL, STRLEN(NATIVE_TTEOL));
 				dx = 0;
@@ -621,7 +665,9 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 				async_action(FALSE);
 				break;
 			}
-			if (((0 != (mask & TRM_ESCAPE)) || edit_mode)
+
+			//kt original --> if (((0 != (mask & TRM_ESCAPE)) || edit_mode)
+			if (((temp_io_state.escape_processing) || edit_mode)  			//kt mod
 			     && ((NATIVE_ESC == inchar) || (START != io_ptr->esc_state)))
 			{
 				if (zb_ptr >= zb_top UTF8_ONLY(|| (utf8_active && ASCII_MAX < inchar)))
@@ -644,33 +690,55 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 				 * --------------------------------------------------------------------
 				 */
 			} else
-			{	/* SIMPLIFY THIS! */
+			{
+				char_is_terminator = IS_TERMINATOR(mask_term.mask, INPUT_CHAR, utf8_active);
+				//Below, UTF and default terminators and UTF terminators above ASCII_MAX
+				char_is_special_terminator = utf8_active && ((u32_line_term[U32_LT_NL] == INPUT_CHAR ||  u32_line_term[U32_LT_LS] == INPUT_CHAR || u32_line_term[U32_LT_PS] == INPUT_CHAR));
+
+				/*  //kt simplifying code
+				// SIMPLIFY THIS!
 				if (!utf8_active || ASCII_MAX >= INPUT_CHAR)
-				{	/* may need changes to allow terminator > MAX_ASCII and/or LS and PS if default_mask_term */
+				{	// may need changes to allow terminator > MAX_ASCII and/or LS and PS if default_mask_term
 					msk_num = (uint4)INPUT_CHAR / NUM_BITS_IN_INT4;
 					msk_in = (1 << ((uint4)INPUT_CHAR % NUM_BITS_IN_INT4));
 					if (msk_in & mask_term.mask[msk_num])
 					{
 						*zb_ptr++ = (unsigned char)INPUT_CHAR;
 						if (utf8_active && ASCII_CR == INPUT_CHAR)
-							tt_ptr->discard_lf = TRUE;
+							temp_io_state.discard_lf = TRUE;  //kt mod  Added 'temp_io_state.'
 						break;
 					}
-				} else if (utf8_active && tt_ptr->default_mask_term && (u32_line_term[U32_LT_NL] == INPUT_CHAR ||
-					u32_line_term[U32_LT_LS] == INPUT_CHAR || u32_line_term[U32_LT_PS] == INPUT_CHAR))
+				*/
+
+				if (char_is_terminator)	   //kt mod  Simplifying boolean logic
+				{
+					*zb_ptr++ = (unsigned char)INPUT_CHAR;
+					if (utf8_active && ASCII_CR == INPUT_CHAR)
+						temp_io_state.discard_lf = TRUE;  //kt mod  Added 'temp_io_state.'
+					break;
+				} else if (char_is_special_terminator && temp_io_state.default_mask_term)  //kt mod  Simplifying boolean logic
 				{	/* UTF and default terminators and UTF terminators above ASCII_MAX */
 					zb_ptr = UTF8_WCTOMB(INPUT_CHAR, zb_ptr);
 					break;
 				}
-				assert(0 <= instr);
+				/* //kt  original bool test below
+				} else if (utf8_active && temp_io_state.default_mask_term && (u32_line_term[U32_LT_NL] == INPUT_CHAR ||  //kt mod  Added 'temp_io_state.'
+					u32_line_term[U32_LT_LS] == INPUT_CHAR || u32_line_term[U32_LT_PS] == INPUT_CHAR))
+				{
+					zb_ptr = UTF8_WCTOMB(INPUT_CHAR, zb_ptr);
+					break;
+				}
+				*/
+			assert(0 <= instr);
 				assert(!edit_mode || 0 <= dx);
 				assert(outlen >= instr);
 				/* For most of the terminal the 'kbs' string capability is a byte in length. It means that it is
 				  Not treated as escape sequence. So explicitly check if the input corresponds to the 'kbs' */
-				if ((((int)inchar == tt_ptr->ttio_struct->c_cc[VERASE]) ||
+				if ((((int)inchar == temp_io_state.ttio_struct.c_cc[VERASE]) ||    //kt mod  Added 'io_state.' and changed '->cc' to '.cc'
 				    (empterm && (NULL != KEY_BACKSPACE) && ('\0' == KEY_BACKSPACE[1])
 				     && (inchar == KEY_BACKSPACE[0])))
-				    && !(mask & TRM_PASTHRU))
+				     //kt original --> && !(mask & TRM_PASTHRU))
+				     && (temp_io_state.passthru == FALSE))  					//kt mod
 				{
 					if (0 < instr && (edit_mode || 0 < dx))
 					{
@@ -678,7 +746,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 						delchar_width = dx_instr - dx_prev;
 						if (edit_mode)
 						{
-							if (!(mask & TRM_NOECHO))
+							//kt original --> if (!(mask & TRM_NOECHO))
+							if (echo_mode)  					//kt mod
 								move_cursor_left(dx, delchar_width);
 							dx = (dx - delchar_width + ioptr_width) % ioptr_width;
 						} else
@@ -687,12 +756,14 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 						dx_instr -= delchar_width;
 						STORE_OFF(' ', outlen);
 						outlen--;
-						if (!(mask & TRM_NOECHO) && edit_mode)
+						//kt original --> if (!(mask & TRM_NOECHO) && edit_mode)
+						if (echo_mode && edit_mode)  					//kt mod
 						{
 							IOTT_COMBINED_CHAR_CHECK;
 						}
 						MOVE_BUFF(instr, BUFF_ADDR(instr + 1), outlen - instr);
-						if (!(mask & TRM_NOECHO))
+						//kt original --> if (!(mask & TRM_NOECHO))
+						if (echo_mode)  						//kt mod
 						{
 							if (!edit_mode)
 							{
@@ -736,12 +807,14 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 					{
 						case EDIT_SOL:	/* ctrl A  start of line */
 						{
-							IOTT_MOVE_START_OF_LINE(tt_ptr->fildes, dx, dx_instr, dx_start, ioptr_width, mask, term_error_line, instr);
+							//kt IOTT_MOVE_START_OF_LINE(tt_ptr->fildes, dx, dx_instr, dx_start, ioptr_width, mask, term_error_line, instr);
+							IOTT_MOVE_START_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, ioptr_width, term_error_line, instr);
 							break;
 						}
 						case EDIT_EOL:	/* ctrl E  end of line */
 						{
-							IOTT_MOVE_END_OF_LINE(tt_ptr->fildes, dx, dx_instr, dx_start, dx_outlen, ioptr_width, mask, term_error_line, instr, outlen);
+							//kt IOTT_MOVE_END_OF_LINE(tt_ptr->fildes, dx, dx_instr, dx_start, dx_outlen, ioptr_width, mask, term_error_line, instr, outlen);
+							IOTT_MOVE_END_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, dx_outlen, ioptr_width, term_error_line, instr, outlen);
 							break;
 						}
 						case EDIT_LEFT:	/* ctrl B  left one */
@@ -751,7 +824,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 								dx_prev = compute_dx(BUFF_ADDR(0), instr - 1,
 												ioptr_width, dx_start);
 								inchar_width = dx_instr - dx_prev;
-								if (!(mask & TRM_NOECHO))
+								//kt original --> if (!(mask & TRM_NOECHO))
+								if (echo_mode)  //kt mod
 								{
 									if (0 != move_cursor_left(dx, inchar_width))
 									{
@@ -772,7 +846,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 								dx_next = compute_dx(BUFF_ADDR(0), instr + 1,
 												ioptr_width, dx_start);
 								inchar_width = dx_next - dx_instr;
-								if (!(mask & TRM_NOECHO))
+								//kt original --> if (!(mask & TRM_NOECHO))
+								if (echo_mode)  //kt mod
 								{
 									if (0 != move_cursor_right(dx, inchar_width))
 									{
@@ -788,7 +863,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 						}
 						case EDIT_DEOL:	/* ctrl K  delete to end of line */
 						{
-							if (!(mask & TRM_NOECHO))
+							//kt original --> if (!(mask & TRM_NOECHO))
+							if (echo_mode)  //kt mod
 							{
 								if (0 != write_str_spaces(dx_outlen - dx_instr, dx, FALSE))
 								{
@@ -810,7 +886,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 											ioptr_width;
 							num_chars_left = dx - dx_start;
 							SET_BUFF(0, ' ', outlen);
-							if (!(mask & TRM_NOECHO))
+							//kt original --> if (!(mask & TRM_NOECHO))
+							if (echo_mode)  //kt mod
 							{
 								status = move_cursor(tt_ptr->fildes,
 									num_lines_above, num_chars_left);
@@ -833,12 +910,14 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 							{
 								STORE_OFF(' ', outlen);
 								outlen--;
-								if (!(mask & TRM_NOECHO))
+								//kt original --> if (!(mask & TRM_NOECHO))
+								if (echo_mode)  //kt mod
 								{
 									IOTT_COMBINED_CHAR_CHECK;
 								}
 								MOVE_BUFF(instr, BUFF_ADDR(instr + 1), outlen - instr);
-								if (!(mask & TRM_NOECHO))
+								//kt original --> if (!(mask & TRM_NOECHO))
+								if (echo_mode)  //kt mod
 								{	/* First write spaces on all the display columns that
 									 * the current string occupied. Then overwrite that
 									 * with the new string. This way we are guaranteed all
@@ -873,7 +952,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 								}
 							}
 							STORE_OFF(inchar, instr);
-							if (!(mask & TRM_NOECHO))
+							//kt original --> if (!(mask & TRM_NOECHO))
+							if (echo_mode)  //kt mod
 							{
 								if (!edit_mode)
 								{
@@ -919,7 +999,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 							{	/* Compute value of dollarx at the new cursor position */
 								dx_cur = compute_dx(BUFF_ADDR(0), instr, ioptr_width, dx_start);
 								inchar_width = dx_cur - dx_instr;
-								if (!(mask & TRM_NOECHO))
+								//kt original --> if (!(mask & TRM_NOECHO))
+								if (echo_mode)  //kt mod
 								{
 									term_error_line = __LINE__;
 									status = move_cursor_right(dx, inchar_width);
@@ -1019,7 +1100,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 				{	/* Move one character to the left */
 					dx_prev = compute_dx(BUFF_ADDR(0), instr - 1, ioptr_width, dx_start);
 					delchar_width = dx_instr - dx_prev;
-					if (!(mask & TRM_NOECHO))
+					//kt original --> if (!(mask & TRM_NOECHO))
+					if (echo_mode)  //kt mod
 					{
 						term_error_line = __LINE__;
 						status = move_cursor_left(dx, delchar_width);
@@ -1032,12 +1114,14 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 				{
 					STORE_OFF(' ', outlen);
 					outlen--;
-					if (!(mask & TRM_NOECHO))
+					//kt original --> if (!(mask & TRM_NOECHO))
+					if (echo_mode)  //kt mod
 					{
 						IOTT_COMBINED_CHAR_CHECK;
 					}
 					MOVE_BUFF(instr, BUFF_ADDR(instr + 1), outlen - instr);
-					if (!(mask & TRM_NOECHO))
+					//kt original --> if (!(mask & TRM_NOECHO))
+					if (echo_mode)  //kt mod
 					{	/* First write spaces on all the display columns that the current string occupied.
 						 * Then overwrite that with the new string. This way we are guaranteed all
 						 * display columns are clean.
@@ -1119,7 +1203,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 				dx = (unsigned)(dx_instr + dx_start) % ioptr_width;
 				outlen = instr;
 				escape_edit = TRUE;
-			} else if (!(mask & TRM_NOECHO))
+			//kt original --> } else if (!(mask & TRM_NOECHO))
+			} else if (echo_mode)  //kt mod
 			{
 				// When the cursor is at the beginning of the line, we can move it 1 position to the right or to the end of the line.
 				// I have grouped these possibilities in pair. This is more understandable and logical. Sergey Kamenev.
@@ -1138,7 +1223,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 						dx = (dx + inchar_width) % ioptr_width;
 						dx_instr += inchar_width;
 					} else if (0 == end) /* End - end of line */
-						IOTT_MOVE_END_OF_LINE(tt_ptr->fildes, dx, dx_instr, dx_start, dx_outlen, ioptr_width, mask, term_error_line, instr, outlen);
+						//kt original --> IOTT_MOVE_END_OF_LINE(tt_ptr->fildes, dx, dx_instr, dx_start, dx_outlen, ioptr_width, mask, term_error_line, instr, outlen);
+						IOTT_MOVE_END_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, dx_outlen, ioptr_width, term_error_line, instr, outlen);
 				}
 				// When the cursor is at the end of the line, we can move it 1 position to the left or to the beginning of the line.
 				if (0 != instr)
@@ -1156,14 +1242,16 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 						dx = (dx - inchar_width + ioptr_width) % ioptr_width;
 						dx_instr -= inchar_width;
 					} else if (0 == home) /* Home - start of line */
-					    IOTT_MOVE_START_OF_LINE(tt_ptr->fildes, dx, dx_instr, dx_start, ioptr_width, mask, term_error_line, instr);
+					    //kt original --> IOTT_MOVE_START_OF_LINE(tt_ptr->fildes, dx, dx_instr, dx_start, ioptr_width, mask, term_error_line, instr);
+					    IOTT_MOVE_START_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, ioptr_width, term_error_line, instr);
 				}
 			}
 			if (0 == insert_key)
 				insert_mode = !insert_mode;	/* toggle */
 			if (0 == right || 0 == left || 0 == insert_key)
 				escape_edit = TRUE;
-			if (escape_edit || (0 == (TRM_ESCAPE & mask)))
+			//kt original --> if (escape_edit || (0 == (TRM_ESCAPE & mask)))
+			if (escape_edit || (temp_io_state.escape_processing == FALSE))   //kt mod
 			{	/* reset dollar zb if editing function or not trm_escape */
 				memset(io_ptr->dollar.zb, '\0', SIZEOF(io_ptr->dollar.zb));
 				io_ptr->esc_state = START;
@@ -1193,7 +1281,8 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 		if (0 == outlen && ((io_ptr->dollar.zb + 1) == zb_ptr)) /* No input and no delimiter seen */
 			ret = FALSE;
 	}
-	if (mask & TRM_READSYNC)
+	//kt original --> if (mask & TRM_READSYNC)
+	if (temp_io_state.readsync)  //kt mod
 	{
 		DOWRITERC(tt_ptr->fildes, &dc3, 1, status);
 		if (0 != status)
@@ -1224,11 +1313,12 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 		v->str.len = INTCAST(outptr - buffer_start);
 	} else
 #	endif
-		v->str.len = outlen;
+	v->str.len = outlen;
 	v->str.addr = (char *)buffer_start;
 	if (edit_mode)	/* store in recall buffer */
 		iott_recall_array_add(tt_ptr, outlen, dx_outlen, BUFF_CHAR_SIZE * outlen, BUFF_ADDR(0));
-	if (!(mask & TRM_NOECHO))
+	//kt original --> if (!(mask & TRM_NOECHO))
+	if (echo_mode)  //kt mod
 	{
 		if ((io_ptr->dollar.x += dx_outlen) >= ioptr_width && io_ptr->wrap)
 		{
@@ -1241,13 +1331,15 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 		}
 	}
 	REVERT_GTMIO_CH(&io_curr_device, ch_set);
-	RESETTERM_IF_NEEDED(io_ptr, EXPECT_SETTERM_DONE_TRUE);
+
+	iott_restoreterm(io_ptr); //kt added.  Restore ydb's current IO state, in case this function modified the TTY IO subsystem.
+
 	return ((short)ret);
 
 term_error:
 	save_errno = errno;
 	io_ptr->dollar.za = ZA_IO_ERR;
-	tt_ptr->discard_lf = FALSE;
+	temp_io_state.discard_lf = FALSE;  //kt mod  Added 'temp_io_state.
 	SEND_KEYPAD_LOCAL;	/* to turn keypad off if possible */
 	if (!nsec_timeout)
 		iott_rterm(io_ptr);

--- a/sr_unix/iott_resetterm.c
+++ b/sr_unix/iott_resetterm.c
@@ -38,38 +38,113 @@ GBLREF	boolean_t	exit_handler_active;
 
 error_def(ERR_TCSETATTR);
 
-void  iott_resetterm(io_desc *iod)
+void  iott_resetterm(io_desc * io_ptr)
+/* ----------------------------------------------------------------------------------------------------------------------
+//kt ADDED NOTES
+PURPOSE: Initially restterm() was called at end of TTY READ's, which caused problems.  Text here will describe some of those
+	 problems and modifications applied to improve performance.
+
+	With original functionality, iott_resetterm() was called after each IO read call, often via macro RESETTERM_IF_NEEDED.
+	This could happen multiple times in a single line of code. For example:
+
+	      USE $P:NOECHO READ *X hang 1 READ Y#1 hang 1 READ Z
+
+	  After each of these READ's, before proceeding to the next command, a iott_resetterm would  be called.
+	  The ideas seemed to be that each command may need to set the IO state in some special way, so when done,
+	  it would reset the TTY IO system.
+	  A problem arose from this system, however was that this caused an unexpected state **inbetween** IO reads.
+	  One would expect that the IO state would be NOECHO during the 1 second of HANG in the example above.
+	  But if terminal is reset to initial entry IO state after each READ, then the system would actually be back in
+	  ECHO mode during the hang. And if the user typed characters during this 1 second, then they would be shown in
+	  terminal output -- put there by the TTY IO subsystem.
+	  The codebase has now been modified such that instead of calling iott_resetterm() after READ commands, the TTY IO READ's
+	  will call a new function called iott_restoreterm(), which will just restore the current ydb compiled IO state.
+	  In the example above, it would restore the NOECHO state, not reset to ECHO mode.
+
+	The TTY IO subsystem is controlled by sending a ttio_struct with bitflags specifying the various settings.
+	  Ydb will maintain a copy of this struct in io_state.ttio_struct.
+	Ydb also has settings on how it manages input, which needs to cooperate with the TTY IO settings.  Previously,
+	  these ydb settings were stored in tt_ptr->term_ctrl, using a different set of bitflags.  However, in order
+	  to make the logic of this control more clear, these settings have now been moved into discrete boolean variables
+	  in tt_ptr->io_state.  For example, tt_ptr->io_state.devparam_echo.  This has removed all TRM_NOECHO etc flags
+	  from the codebase.
+
+	One might wonder, if the terminal is reset after every IO command, how will the next IO command be completed
+	  in the proper IO state?  The answer would be that at the BEGINNING of each IO command, setterm() is called,
+	  often via macro SETTERM_IF_NEEDED.  This ensured that ydb's current working IO state (based on USE commands
+	  etc) is applied to the TTY IO system before completing the upcoming IO command.
+
+	Using iott_restoreterm() instead of iott_resetterm() after commands fixed issues with unexpected state between IO calls,
+	  as shown above. But there still is a role for iott_resetterm, esp after a direct mode (DM) command is completed.
+	  More on this below.
+	When analyzing the codebase to correct above issues, it was initially difficult to determine the purpose of iott_resetterm().
+	  Obviously iott_resetterm() was supposed to reset the terminal.  But _when_ should the terminal be reset, and
+	  _to_what_state_ should the terminal be returned to?  The IO state when ydb first started?  Or
+	  the IO state after $P has been initialized with USE parameters?  Or from the last USE command?
+	  After study, it appeared that iott_resetterm() should return the terminal to the IO state when ydb first started.
+	  This would ensure that any interaction with the user in direct mode will be under the same conditions as
+	  when ydb was launched.
+
+	Another point to emphasize is that iott_resetterm() should NOT change the "state" of ydb's IO status.  If the user
+	    has specified NOECHO as a USE parameter, this state should be maintained, regardless of resets to the terminal
+	    that might be applied between IO commands.  THEREFORE, this function just ensures that the TTY IO subsystem
+	    matches tt_ptr->initial_ttio_struct.  It doesn't modify, for example, tt_ptr->io_state.canonical.
+	    And it doesn't modify or reset ydb's representation of state.
+
+	When interacting with the user at the console in direct mode (DM), special consideration needs to be given to the
+	  IO state.  For example, if the user enters DM command of "USE $P:NOECHO", then ydb's state should be set
+	  to NOECHO.  And yet, there DOES need to be echo when the user enters their next command, e.g. "READ X".
+	  To handle this situation, before each direct mode command is read from the user, iott_setterm_for_direct_mode() is called.
+	  This maintains the state (in this case "NOECHO") that will need to be reinstated before executing the next command.
+	  Currently, it has been determined that the IO state does not need to be changed at the END of a a DM read. Instead,
+	  it can just be left in the IO state designed for DM mode.  Whenever READ's are called, they will themselves change
+	  to the IO state they need.
+
+	At the end of this iott_resetterm function, tt_ptr->setterm_done_by is set to 0.  This is a signal that ydb needs
+	  to set the terminal based on internal state variables the next time it is needed.  This is checked in setterm().
+
+	Notice that after this iott_resetterm(), the TTY IO system and ydb's internal state (held in .io_state) are out of sync.  But
+	  it will only be this way during DM interaction, and will be corrected with next READ via setterm.
+
+NOTE: renamed "iod" to "io_ptr" for consistency in codebase. Changes not marked.  Just search for "io_ptr"
+        	codebase seems to use names "iod", "ioptr", and "io_ptr" interchangably.
+NOTE: renamed "ttptr" to "tt_ptr" for consistency across codebase.  Changes not marked below, just search for "tt_ptr"
+NOTE: //kt made extensive changes to this function.  Not all are marked.
+----------------------------------------------------------------------------------------------------------------------
+*/
 {
 	int		status;
 	int		save_errno;
 	struct termios 	t;
-	d_tt_struct	*ttptr;
+	d_tt_struct	*tt_ptr;
 
-	ttptr = (d_tt_struct *) iod->dev_sp;
-	if (process_id != ttptr->setterm_done_by)
-		return;	/* "iott_resetterm" already done */
-	if (ttptr->ttio_struct)
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+	if (process_id != tt_ptr->setterm_done_by)
 	{
-	        t = *ttptr->ttio_struct;
-		Tcsetattr(ttptr->fildes, TCSANOW, &t, status, save_errno, CHANGE_TERM_FALSE);
-		if (0 != status)
-		{
-			assert(-1 == status);
-			assert(ENOTTY != save_errno);
-			/* Skip TCSETATTR error for ENOTTY (in case fildes is no longer a terminal) */
-			if ((ENOTTY != save_errno) && (0 == gtm_isanlp(ttptr->fildes)))
-			{
-				ISSUE_NOPRINCIO_BEFORE_RTS_ERROR_IF_APPROPRIATE(iod);	/* just like is done in "iott_use.c" */
-				/* If we are already in the exit handler, do not issue an error for this event as this
-				 * could cause a condition handler overrun (i.e. invoke "ch_overrun()") which would create
-				 * a core file. Since this error most likely means the terminal has gone away, it is better
-				 * to terminate the process without resetting a non-existent terminal than creating a core file.
-				 */
-				if (!exit_handler_active)
-					RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, ttptr->fildes, save_errno);
-			}
-		}
-		ttptr->setterm_done_by = 0;
+		return;	/* "iott_resetterm" already done */
 	}
+
+	//set TTY IO subsystem to value stored in initial_io_state
+	iott_set_tty(io_ptr, &(tt_ptr->initial_io_state.ttio_struct),  SET_TTY_CHECK_ERRORS_MODE_4);
+	iott_set_ydb_echo(io_ptr, &(tt_ptr->initial_io_state), &(tt_ptr->io_state));
+
+	tt_ptr->setterm_done_by = 0;	//<-- This will trigger terminal to be set up again next time used, via setterm()
+
+	//kt printf("debug point 1 in iott_resetterm() in iott_resetterm.c  Setting Echo value to: %d\n", BIT_FLAG_IS_ON (0010, tt_ptr->initial_io_state.ttio_struct.c_lflag));  // ECHO   (0010): 000000001000 Enable echo.
+
 	return;
+}
+
+void  iott_restoreterm(io_desc * io_ptr)
+//kt added function
+//Purpose: This will send currently compiled IO state to the TTY IO subsystem.
+//	   This is different from iott_resetterm(), which will return IO state to same as when ydb first started.
+{
+	d_tt_struct *   		tt_ptr;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+
+	//Send ydb current active state to underlying TTY IO subsystem
+	iott_set_tty_and_ydb_echo(io_ptr, &(tt_ptr->io_state.ttio_struct), SET_TTY_CHECK_ERRORS_MODE_1);
+
+	tt_ptr->setterm_done_by = process_id;  //signal that another TTY IO set is not currently needed.
 }

--- a/sr_unix/iott_setterm.c
+++ b/sr_unix/iott_setterm.c
@@ -20,6 +20,7 @@
 #include "gtm_termios.h"
 #include "gtm_signal.h"	/* for SIGPROCMASK used inside Tcsetattr */
 #include "gtm_unistd.h"
+#include "termios.h" 	 								//kt added
 
 #include "io.h"
 #include "iosp.h"
@@ -28,40 +29,81 @@
 #include "iott_setterm.h"
 #include "eintr_wrappers.h"
 #include "gtm_isanlp.h"
+#include "util_output.h"   								//kt added
+#include "util.h"									//kt added
+#include "send_msg.h"									//kt added
 
 GBLREF	uint4		process_id;
+GBLREF	boolean_t	exit_handler_active;  						//kt added
+GBLREF  boolean_t	err_same_as_out, prin_in_dev_failure, prin_out_dev_failure;	//kt added
 
 error_def(ERR_TCSETATTR);
 
-void iott_setterm(io_desc *ioptr)
+void iott_setterm_for_no_canonical(io_desc * io_ptr,  ttio_state * temp_io_state_ptr)
+//kt added function.
+//Setup terminal with CANONICAL mode OFF.
+//  Needed for reading just one character, e.g. via READ *X command
+//  Also needed for reading fixed length, e.g. READ #1
+//NOTE: This function is different from iott_setterm_for_direct_mode().  That returns a pointer to an existing structure.
+//       But this populates a structure passed in.
+{
+	d_tt_struct*			tt_ptr;
+	ttio_state*			io_state_ptr;
+
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+
+	*temp_io_state_ptr = tt_ptr->io_state;  //start with current io_state
+	temp_io_state_ptr->canonical = FALSE;   //if canonical were left on, then TTY IO subsystem wouldn't return character until after NL (or CR) or EOL
+
+	//kt below does same as iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, SET_TTY_CHECK_ERRORS_MODE_1), but uses temp_io_state
+	iott_compile_ttio_struct(io_ptr, temp_io_state_ptr, 8, 1);
+	iott_set_tty(io_ptr, &(temp_io_state_ptr->ttio_struct), SET_TTY_CHECK_ERRORS_MODE_1);
+	iott_set_ydb_echo(io_ptr, temp_io_state_ptr, temp_io_state_ptr);
+
+	tt_ptr->setterm_done_by = 0;  //signal that terminal will need to be setup again before next use.
+
+	return;
+}
+
+ttio_state* iott_setterm_for_direct_mode(io_desc* io_ptr)
+//kt added function.  Setup terminal for interaction with user at console in direct mode.
+//NOTE: This function is different from iott_setterm_for_no_canonical().  That populates a structure passed in.
+//         Whereas this function returns a pointer to an existing structure.
+{
+	d_tt_struct*			tt_ptr;
+	ttio_state* 			direct_mode_io_state_ptr;
+
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+	direct_mode_io_state_ptr = &(tt_ptr->direct_mode_io_state);
+
+	//kt below does same as iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, SET_TTY_CHECK_ERRORS_MODE_1), but uses direct_mode_io_state
+	iott_compile_ttio_struct(io_ptr, direct_mode_io_state_ptr, 8, 1);
+	iott_set_tty(io_ptr, &(direct_mode_io_state_ptr->ttio_struct), SET_TTY_CHECK_ERRORS_MODE_1);
+	iott_set_ydb_echo(io_ptr, direct_mode_io_state_ptr, direct_mode_io_state_ptr);
+
+	tt_ptr->setterm_done_by = 0;  //signal that terminal will need to be setup again before next use.
+
+	return direct_mode_io_state_ptr;
+}
+
+//kt NOTE: renaming ioptr to io_ptr for consistency in codebase. Changes not marked.  Just search for io_ptr
+//kt NOTE: codebase seems to use names "iod", "ioptr", and io_ptr interchangably.
+void iott_setterm(io_desc * io_ptr)
 {
 	int		status;
 	int		save_errno;
 	struct termios	t;
 	d_tt_struct	*tt_ptr;
 
-	tt_ptr = (d_tt_struct *)ioptr->dev_sp;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
 	if (0 != tt_ptr->setterm_done_by)
 	{
 		assert(process_id == tt_ptr->setterm_done_by);
 		return;	/* "iott_setterm" already done */
 	}
-	t = *tt_ptr->ttio_struct;
-	if (tt_ptr->canonical)
-	{	t.c_lflag &= ~(ECHO);
-		t.c_lflag |= ICANON;
-	}else
-	{	t.c_lflag &= ~(ICANON | ECHO);
-		t.c_cc[VTIME] = 8;
-		t.c_cc[VMIN] = 1;
-	}
-	t.c_iflag &= ~(ICRNL);
-	Tcsetattr(tt_ptr->fildes, TCSANOW, &t, status, save_errno, CHANGE_TERM_TRUE);
-	if (0 != status)
-	{
-		if (gtm_isanlp(tt_ptr->fildes) == 0)
-			RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, tt_ptr->fildes, save_errno);
-	}
+
+	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, SET_TTY_CHECK_ERRORS_MODE_1);  //kt moved block of code into function
+
 	tt_ptr->setterm_done_by = process_id;
 	return;
 }
@@ -76,58 +118,380 @@ void iott_setterm(io_desc *ioptr)
    so that a read with a zero timeout (ie.  Read x:0) will not wait.
 */
 
-void iott_mterm(io_desc *ioptr)
+void iott_mterm(io_desc * io_ptr)
 {
 	int		status;
 	int		save_errno;
 	struct termios	t;
+	cc_t 		vtime;  //kt added
 	d_tt_struct	*tt_ptr;
 
-	tt_ptr = (d_tt_struct *) ioptr->dev_sp;
-	t = *tt_ptr->ttio_struct;
-	if (tt_ptr->canonical)
-	{	t.c_lflag &= ~(ECHO);
-		t.c_lflag |= ICANON;
-	}else
-	{	t.c_lflag &= ~(ICANON | ECHO);
+	tt_ptr = (d_tt_struct *) io_ptr->dev_sp;
+
+	//kt begin addition
 #ifdef __MVS__
-		t.c_cc[VTIME] = 1;
+		vtime = 1;
 #else
-		t.c_cc[VTIME] = 0;
+		vtime = 0;
 #endif
-		t.c_cc[VMIN] = 0;
-	}
-	t.c_iflag &= ~(ICRNL);
-	Tcsetattr(tt_ptr->fildes, TCSANOW, &t, status, save_errno, CHANGE_TERM_TRUE);
-	if (0 != status)
-		rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, tt_ptr->fildes, save_errno);
+	//kt end addition
+
+	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, vtime, 0, SET_TTY_CHECK_ERRORS_MODE_2);  //kt moved block of code into function
+
+	return;
+}
+
+// iott_rterm restores the inter-character timer (t.c_cc[VTIME]) to 0.8 seconds
+void iott_rterm(io_desc *io_ptr)
+{
+	d_tt_struct  	*tt_ptr;
+	tt_ptr = (d_tt_struct *) io_ptr->dev_sp;
+
+	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, SET_TTY_CHECK_ERRORS_MODE_2);  //kt moved block of code into function
+
 	return;
 }
 
 
-/* iott_rterm restores the inter-character timer (t.c_cc[VTIME]) to 0.8 seconds
+void iott_compile_ttio_struct(io_desc * io_ptr, ttio_state* io_state_ptr, cc_t vtime, cc_t vmin)
+//kt added function
+//Purpose: to compile any state variables into ttio_struct, ready to be later passed to TTY IO system
+//         NOTE: Because tt_ptr->io_state.term_ctrl settings have to match TTY IO system, it should also
+//		 be set up -- but will not be handling here.  See iott_set_ydb_echo()
+/*
+Input: io_state_ptr -- pointer to IO state structure
+       vtime  -- sets VTIME parameter (timeout time) if canonical mode
+       vmin   -- sets VMIN parameter (minimum chars to read) if canonical mode
+
+    From: https://www.man7.org/linux/man-pages/man3/termios.3.html
+    VTIME  Timeout in deciseconds for noncanonical read (TIME).
+    VMIN   Minimum number of characters for noncanonical read (MIN). <-- note MIN is not minutes.
+    ...
+     In noncanonical mode input is available immediately (without the
+       user having to type a line-delimiter character), no input
+       processing is performed, and line editing is disabled.  The read
+       buffer will only accept 4095 chars; this provides the necessary
+       space for a newline char if the input mode is switched to
+       canonical.  The settings of MIN (c_cc[VMIN]) and TIME
+       (c_cc[VTIME]) determine the circumstances in which a read(2)
+       completes; there are four distinct cases:
+
+       MIN == 0, TIME == 0 (polling read)
+              If data is available, read(2) returns immediately, with
+              the lesser of the number of bytes available, or the number
+              of bytes requested.  If no data is available, read(2)
+              returns 0.
+
+       MIN > 0, TIME == 0 (blocking read)
+              read(2) blocks until MIN bytes are available, and returns
+              up to the number of bytes requested.
+
+       MIN == 0, TIME > 0 (read with timeout)
+              TIME specifies the limit for a timer in tenths of a
+              second.  The timer is started when read(2) is called.
+              read(2) returns either when at least one byte of data is
+              available, or when the timer expires.  If the timer
+              expires without any input becoming available, read(2)
+              returns 0.  If data is already available at the time of
+              the call to read(2), the call behaves as though the data
+              was received immediately after the call.
+
+       MIN > 0, TIME > 0 (read with interbyte timeout)
+              TIME specifies the limit for a timer in tenths of a
+              second.  Once an initial byte of input becomes available,
+              the timer is restarted after each further byte is
+              received.  read(2) returns when any of the following
+              conditions is met:
+
+              •  MIN bytes have been received.
+              •  The interbyte timer expires.
+              •  The number of bytes requested by read(2) has been
+                 received.  (POSIX does not specify this termination
+                 condition, and on some other implementations read(2)
+                 does not return in this case.)
+
+              Because the timer is started only after the initial byte
+              becomes available, at least one byte will be read.  If
+              data is already available at the time of the call to
+              read(2), the call behaves as though the data was received
+              immediately after the call.
+
+----------------------------------------------------------------------------------------------------------------------------------------
+  //NOTE: Below is definition of flags. Not all are set here, and will just inherit values from initial state, before device was opened.
+
+  tcflag_t c_iflag;	// input mode flags   Note: values below are (OCTAL): binary
+                        // IGNBRK  (0000001): 000000000000000000000001 Ignore break condition.
+                        // BRKINT  (0000002): 000000000000000000000010 Signal interrupt on break.
+                        // IGNPAR  (0000004): 000000000000000000000100 Ignore characters with parity errors.
+                        // PARMRK  (0000010): 000000000000000000001000 Mark parity and framing errors.
+                        // INPCK   (0000020): 000000000000000000010000 Enable input parity check.
+                        // ISTRIP  (0000040): 000000000000000000100000 Strip 8th bit off characters.
+                        // INLCR   (0000100): 000000000000000001000000 Map NL to CR on input.
+                        // IGNCR   (0000200): 000000000000000010000000 Ignore CR.
+                        // ICRNL   (0000400): 000000000000000100000000 Map CR to NL on input.
+                        // IUCLC   (0001000): 000000000000001000000000 Map uppercase characters to lower case on input  (not in POSIX).
+                        // IXON    (0002000): 000000000000010000000000 Enable start/stop output control.
+                        // IXANY   (0004000): 000000000000100000000000 Enable any character to restart  output.
+                        // IXOFF   (0010000): 000000000001000000000000 Enable start/stop input  control.
+                        // IMAXBEL (0020000): 000000000010000000000000 Ring bell wh en input queue is full (not in POSIX).
+                        // IUTF8   (0040000): 000000000100000000000000 Input is UTF8 (not in POSIX).
+The above constants are define in /usr/include/x86_64-linux-gnu/bits/termios-c_iflag.h
+
+  tcflag_t c_oflag;	// output mode flags   //NOTE: doesn't seem to be used in yottadb
+  tcflag_t c_cflag;	// control mode flags  //NOTE: doesn't seem to be used in yottadb
+
+  tcflag_t c_lflag;	// local mode flags  Note: values below are (OCTAL): binary
+                        // ISIG   (0001): 000000000001 Enable signals.
+                        // ICANON (0002): 000000000010 Canonical input (erase and kill processing).
+                        // XCASE  (0004): 000000000100 (obsolete), Flip upper and lower case (not in POSIX)
+                        // ECHO   (0010): 000000001000 Enable echo.
+                        // ECHOE  (0020): 000000010000 Echo erase character as error-correcting backspace
+                        // ECHOK  (0040): 000000100000 Echo KILL.
+                        // ECHONL (0100): 000001000000 Echo NL.
+                        // NOFLSH (0200): 000010000000 Disable flush after interrupt or quit.
+                        // TOSTOP (0400): 000100000000 Send SIGTTOU for background output.
+The above constants are define in /usr/include/x86_64-linux-gnu/bits/termios-c_lflag.h
+
+NOTE:  For TTY IO signals, e.g. ISIG (enable signals), that are never modified by YDB, the state will not
+       be stored in separate tt_ptr->io_state.* variables.  Instead the combined state will be contained in
+       tty_ptr->io_state.ttio_struct and tty_ptr->initial_io_state.ttio_struct
+
+NOTE!! --> One of the most confusing elements of IO state is echo status!
+	This stems, in part, because for things to work properly BOTH the TTY IO subsystem AND ydb's settings
+  	have to be configured correctly to work together.
+
+Here are the various parts to consider:
+  -- ECHO mode as a device parameter.  E.g.  USE $P:NOECHO    Stored in io_state.devparam_echo
+  -- The bit flag in the ttio_struct specifying TTY IO echo status.  E.g. 000000010
+  -- ydb settings for echo.  Previously stored in .term_ctrl, but now stored in io_state.ydb_echo boolean
+  These are not redundant, and have to be stored separately.
+
+When CANONICAL mode is active, there is an extra layer of complexity because is affects the behavior of echo.
+
+In the table below are all combinations of 4 relevant variables, giving 16 combination.
+  -- "PARAM CANONICAL" is the device parameter [NO]CANONICAL.  e.g. USE $P:CANONICAL
+  -- "PARAM ECHO" is the device parameter [NO]ECHO.  E.g.  USE $P:NOECHO
+  -- "TTY ECHO" means the bit flag that will be sent to the TTY IO subsystem
+  -- "io_state.ydb_echo" means the ydb settings which determine if it provides echo for input.
+
+As user types "hello<return>, what happens in each case?
+
+NOTE: In table below, "H e l l o" is used to show that characters are returned one at a time, not that space is added between.
+
+      PARAM      PARAM                 io_state.
+     CANONICAL   ECHO     TTY ECHO     ydb_echo     USER TYPES         TTY OUTPUTS   YDB OUTPUTS   NET OUTPUT       COMMENT
+ 1     (+)        (+)       (+)         (-)         Hello<enter>         Hello         ""              Hello         OK
+ 2     (+)        (+)       (+)         (+)         Hello<enter>         Hello        Hello         Hello Hello      BAD
+ 3     (+)        (+)       (-)         (-)         Hello<enter>          ""           ""                ""          violates PARAM ECHO (+)
+ 4     (+)        (+)       (-)         (+)         Hello<enter>          ""          Hello            Hello         BAD because output only appears AFTER <enter>
+ 5     (+)        (-)       (+)         (-)         Hello<enter>         Hello        ""               Hello         violates  PARAM ECHO (-)
+ 6     (+)        (-)       (+)         (+)         Hello<enter>         Hello        ""               Hello         violates  PARAM ECHO (-)
+ 7     (+)        (-)       (-)         (-)         Hello<enter>          ""          ""               ""            OK
+ 8     (+)        (-)       (-)         (+)         Hello<enter>          ""          Hello            Hello         violates PARAM ECHO (-)
+ 9     (-)        (+)       (+)         (-)         Hello<enter>        H e l l o      ""              Hello         OK
+10     (-)        (+)       (+)         (+)         Hello<enter>        H e l l o    H e l l o        HHeelloo       BAD
+11     (-)        (+)       (-)         (-)         Hello<enter>           ""          ""              ""            violates PARAM ECHO (+)
+12     (-)        (+)       (-)         (+)         Hello<enter>           ""        H e l l o         Hello         OK
+13     (-)        (-)       (+)         (-)         Hello<enter>        H e l l o      ""              Hello         volates PARAM ECHO (-)
+14     (-)        (-)       (+)         (+)         Hello<enter>        H e l l o    H e l l o        HHeelloo       volates PARAM ECHO (-)
+15     (-)        (-)       (-)         (-)         Hello<enter>           ""          ""               ""           OK
+16     (-)        (-)       (-)         (+)         Hello<enter>           ""        H e l l o         Hello         violates PARAM ECHO (-)
+
+SUMMARY OF ACCEPTABLE CONFIGURATIONS
+
+      PARAM      PARAM                io_state.
+     CANONICAL   ECHO     TTY ECHO     ydb_echo     USER TYPES         TTY OUTPUTS   YDB OUTPUTS   NET OUTPUT       COMMENT
+ 1     (+)        (+)       (+)         (-)         Hello<enter>         Hello         ""              Hello         OK
+ 7     (+)        (-)       (-)         (-)         Hello<enter>          ""           ""                ""          OK
+ 9     (-)        (+)       (+)         (-)         Hello<enter>        H e l l o      ""              Hello         OK
+12     (-)        (+)       (-)         (+)         Hello<enter>          ""         H e l l o         Hello         OK
+15     (-)        (-)       (-)         (-)         Hello<enter>          ""           ""                ""          OK
+
+The above shows that if the user DOES want output [CANONICAL (-) and PARAM ECHO (+)],  (items 9 & 12) then this can be achieve two different ways:
+ 9 -- TTY (+) and io_state.ydb_echo (-)   <--- This lets TTY IO take care of output
+12 -- TTY (-) and io_state.ydb_echo (+)   <--- This lets YDB take care of output  (preferred)
+
+Will exclude #9, and use #12 instead, and we therefore have this logic:
+
+PARAM CANONICAL --> TTY CANONICAL  <-- direct sync between these two.
+
+     PARAM     PARAM
+   CANONICAL   ECHO      -->  TTY ECHO                                 io_state.ydb_echo
+ 1    (+)       (+)      -->    (+)       FYI, to be set elsewhere --> (-)
+ 7    (+)       (-)      -->    (-)       FYI, to be set elsewhere --> (-)
+12    (-)       (+)      -->    (-)       FYI, to be set elsewhere --> (+)
+15    (-)       (-)      -->    (-)       FYI, to be set elsewhere --> (-)
+
+The reason that io_state.ydb_echo is NOT set here is because there is a case where initial_io_state needs
+  to be source instead of io_state. So this will be set in a separate function, iott_set_ydb_echo()
+  //kt update: after changing this function to accept arbitrary io_state_ptr, perhaps all could be done in this one function.  Would need to be researched.
+
 */
-
-void iott_rterm(io_desc *ioptr)
 {
-	int		status;
-	int		save_errno;
-	struct termios	t;
-	d_tt_struct  	*tt_ptr;
+	d_tt_struct * 		tt_ptr;
+	tt_ptr = (d_tt_struct *) io_ptr->dev_sp;
+	struct termios		t;
 
-	tt_ptr = (d_tt_struct *) ioptr->dev_sp;
-	t = *tt_ptr->ttio_struct;
-	if (tt_ptr->canonical)
-	{	t.c_lflag &= ~(ECHO);
-		t.c_lflag |= ICANON;
-	}else
-	{	t.c_lflag &= ~(ICANON | ECHO);
-		t.c_cc[VTIME] = 8;
-		t.c_cc[VMIN] = 1;
+	//Start with TTY IO state from when first entered ydb.
+	t = tt_ptr->initial_io_state.ttio_struct;  //kt mod
+
+	if (io_state_ptr->canonical)
+	{
+		SET_BIT_FLAG_ON(ICANON, t.c_lflag);
+
+		//NOTE: In canonical mode, the TTY system won't end input until newline (NL) found.
+		//	To enable termination on CR (enter key), then must enable CR->NL mapping.
+		SET_BIT_FLAG_ON(ICRNL, t.c_iflag); 	//turn ON ICRNL  = turn ON  Map CR to NL on input.
+		SET_BIT_FLAG_OFF(INLCR, t.c_iflag); 	//turn OFF INLCR = turn OFF Map NL to CR on input.
+
+		//	   PARAM     PARAM
+		//	  CANONICAL   ECHO      -->  TTY ECHO                                  io_state.ydb_echo
+		//     1    (+)       (+)             (+)         FYI, to be set elsewhere --> (-)
+		//     7    (+)       (-)             (-)         FYI, to be set elsewhere --> (-)
+		SET_BIT_FLAG_BY_BOOL(io_state_ptr->devparam_echo, ECHO, t.c_lflag);
+		//note: io_state.ydb_echo also needs to be set.  Will be done in iott_set_ydb_echo()
+
+	} else  //NOT canonical
+	{
+		//	   PARAM     PARAM
+		//	  CANONICAL   ECHO      -->  TTY ECHO                                io_state.ydb_echo
+		//    12    (-)       (+)             (-)       FYI, to be set elsewhere --> (+)
+		//    15    (-)       (-)             (-)       FYI, to be set elsewhere --> (-)
+
+		SET_BIT_FLAG_OFF(ICANON, t.c_lflag);	//turn OFF ICANON = turn off TTY canonical mode
+		SET_BIT_FLAG_OFF(ICRNL,  t.c_iflag);	//turn OFF ICRNL  = turn OFF Map CR to NL on input.
+		SET_BIT_FLAG_OFF(INLCR,  t.c_iflag);	//turn OFF INLCR  = turn OFF Map NL to CR on input.
+
+		t.c_cc[VTIME] = vtime;			//kt doc: this is deciseconds of timeout length
+		t.c_cc[VMIN] = vmin;			//kt doc: this is minimum number of chars to read (min is NOT 'minutes')
+
+		SET_BIT_FLAG_OFF(ECHO, t.c_lflag);	//turn OFF TTY echo
+		//note: io_state.ydb_echo also needs to be set.  Will be done in iott_set_ydb_echo()
+
 	}
-	t.c_iflag &= ~(ICRNL);
-	Tcsetattr(tt_ptr->fildes, TCSANOW, &t, status, save_errno, CHANGE_TERM_TRUE);
-	if (0 != status)
-		rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, tt_ptr->fildes, save_errno);
-	return;
+	SET_BIT_FLAG_BY_BOOL(io_state_ptr->hostsync, IXOFF, t.c_iflag);  // start/stop input control
+	SET_BIT_FLAG_BY_BOOL(io_state_ptr->ttsync,   IXON,  t.c_iflag);  // start/stop output control
+
+	//Save compiled ttio_struct
+	//Should contain all state elements from tt_ptr->io_state
+	io_state_ptr->ttio_struct = t;  //kt mod
+}
+
+void iott_set_ydb_echo(io_desc* io_ptr, ttio_state* source_io_state_ptr, ttio_state* output_io_state_ptr)
+//kt added
+//Purpose: Setup output_io_state_ptr->ydb_echo settings have to match passed *source_io_state_ptr
+//
+//The reason that io_state.ydb_echo is set separately here is because there is a case where initial_io_state needs
+//  to be the source instead of io_state.
+
+//       PARAM     PARAM
+//     CANONICAL   ECHO     -->   io_state.ydb_echo
+// 1     (+)       (+)      -->   (-)
+// 7     (+)       (-)      -->   (-)
+// 12    (-)       (+)      -->   (+)
+// 15    (-)       (-)      -->   (-)
+
+{
+	d_tt_struct *   		tt_ptr;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+
+	if (source_io_state_ptr->canonical)
+	{
+		//configuration #1 & #7 from table above
+		output_io_state_ptr->ydb_echo = FALSE;
+
+	} else  //NOT canonical
+	{
+		//configuration #12 & #15 from table in iott_compile_ttio_struct above
+		output_io_state_ptr->ydb_echo = source_io_state_ptr->devparam_echo;
+	}
+}
+
+
+tty_getsetattr_status iott_compile_state_and_set_tty_and_ydb_echo(io_desc * io_ptr, cc_t vtime, cc_t vmin, tty_err_mode_type err_check_mode)
+//kt added function
+//PURPOSE: To create common function for compiling ydb IO state and then setting tty io system.
+//Input:  io_ptr -- 		pointer to relevant IO structure.  NOTE: other places in codebase used "iod" for this pointer
+//        vtime  -- 		timeout in deciseconds if noncanonical read (VTIME).  E.g. '8' --> 0.8 sec timeout.
+//        vmin   -- 		minimum number of characters if noncanonical read (VMIN)
+//        err_check_mode -- 	determines how error state is handled.
+
+{
+	tty_getsetattr_status	status;
+	d_tt_struct *   	tt_ptr;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+
+	iott_compile_ttio_struct(io_ptr,  &(tt_ptr->io_state), vtime, vmin);   //compiles IO state into io_state.ttio_struct
+	status = iott_set_tty_and_ydb_echo(io_ptr, &(tt_ptr->io_state.ttio_struct), err_check_mode);	//send to underlying TTY IO subsystem
+	return status;
+}
+
+tty_getsetattr_status iott_set_tty_and_ydb_echo(io_desc* io_ptr, struct termios* ttio_struct_ptr, tty_err_mode_type err_check_mode)
+//kt added
+{
+	tty_getsetattr_status		status;
+	d_tt_struct *   		tt_ptr;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+
+	status = iott_set_tty(io_ptr, ttio_struct_ptr, err_check_mode);
+	iott_set_ydb_echo(io_ptr, &(tt_ptr->io_state), &(tt_ptr->io_state));
+
+	return status;
+}
+
+tty_getsetattr_status iott_set_tty(io_desc * io_ptr, struct termios * ttio_struct_ptr, tty_err_mode_type err_check_mode)
+//kt added function
+//PURPOSE: To create common function for actually setting tty io system.
+//Input:  io_ptr -- 		pointer to relevant IO structure.
+//        ttio_struct_ptr --	pointer to ttio_struct data structure to send to TTY IO subsystem
+//        err_check_mode --	determines how error state is handled.
+//NOTE: io_state.ydb_echo needs to match the TTY IO settings, but it is not handled here.  See iott_set_ydb_echo()
+{
+	tty_getsetattr_status		status;
+	int				save_errno;
+	int				filedes;
+	d_tt_struct *   		tt_ptr;
+	DCL_THREADGBL_ACCESS;
+
+	SETUP_THREADGBL_ACCESS;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+	filedes = tt_ptr->fildes;
+
+	Tcsetattr(filedes, TCSANOW, ttio_struct_ptr, status, save_errno, CHANGE_TERM_TRUE); //send ttio_struct_ptr to TTY IO subsystem
+	if (GETSETATTR_SUCCESS != status)
+	{
+		if (err_check_mode == SET_TTY_CHECK_ERRORS_MODE_1)
+		{
+			if (gtm_isanlp(filedes) == 0)
+				RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, filedes, save_errno);
+
+		} else if (err_check_mode == SET_TTY_CHECK_ERRORS_MODE_2)
+		{
+			rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, filedes, save_errno);
+
+		} else if  (err_check_mode == SET_TTY_CHECK_ERRORS_MODE_3)
+		{
+			assert(WBTEST_YDB_KILL_TERMINAL == ydb_white_box_test_case_number);
+			ISSUE_NOPRINCIO_BEFORE_RTS_ERROR_IF_APPROPRIATE(io_ptr);
+			RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, filedes, save_errno);
+
+		} else if  (err_check_mode == SET_TTY_CHECK_ERRORS_MODE_4)
+		{
+			assert(GETSETATTR_FAILURE == status);
+			assert(ENOTTY != save_errno);
+			// Skip TCSETATTR error for ENOTTY (in case fildes is no longer a terminal)
+			if ((ENOTTY != save_errno) && (0 == gtm_isanlp(filedes)))
+			{
+				ISSUE_NOPRINCIO_BEFORE_RTS_ERROR_IF_APPROPRIATE(io_ptr);	// just like is done in "iott_use.c"
+				// If we are already in the exit handler, do not issue an error for this event as this
+				// could cause a condition handler overrun (i.e. invoke "ch_overrun()") which would create
+				// a core file. Since this error most likely means the terminal has gone away, it is better
+				// to terminate the process without resetting a non-existent terminal than creating a core file.
+				//
+				if (!exit_handler_active)
+					RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, filedes, save_errno);
+			}
+		}
+	}
+	return status;
 }

--- a/sr_unix/mupip_main.c
+++ b/sr_unix/mupip_main.c
@@ -104,7 +104,7 @@ int mupip_main(int argc, char **argv, char **envp)
 	sig_init(ydb_os_signal_handler, NULL, suspsigs_handler, continue_handler);	/* Note: no ^C handler is defined (yet) */
 	licensed = TRUE;
 	in_backup = FALSE;
-	op_open_ptr = mu_op_open;
+	op_open_ptr = mu_op_open;		//kt doc: NOTE that this assigning a function pointer, not calling function()
 	INIT_FNPTR_GLOBAL_VARIABLES;
 	mu_get_term_characterstics();
 	ydb_chk_dist(argv[0]);

--- a/sr_unix/readline.c
+++ b/sr_unix/readline.c
@@ -798,7 +798,8 @@ int readline_startup_hook(void) {
 	*vrl_already_prompted = 0;
 
 	/* Insert mode from ydb_principal_editing="[NO]INSERT" */
-	insert_mode = !(TT_NOINSERT & tt_ptr->ext_cap);
+	//kt original --> insert_mode = !(TT_NOINSERT & tt_ptr->ext_cap);
+	insert_mode = BIT_FLAG_IS_OFF(TT_NOINSERT, tt_ptr->io_state.ext_cap); 		//kt mod
 	if (!insert_mode) {
 		/* Activate OVERWRITE mode */
 		frl_overwrite_mode(1,0);

--- a/sr_unix/util_output.c
+++ b/sr_unix/util_output.c
@@ -49,6 +49,7 @@
 #include "gtm_multi_proc.h"
 #include "get_syslog_flags.h"
 #include "get_comm_info.h"
+#include "util_output.h"  			//kt created header file to achieve compilation
 
 #ifdef UTF8_SUPPORTED
 #include "gtm_icu_api.h"

--- a/sr_unix/util_output.h
+++ b/sr_unix/util_output.h
@@ -1,0 +1,39 @@
+/****************************************************************
+ *								*
+ * Copyright (c) 2001-2023 Fidelity National Information	*
+ * Services, Inc. and/or its subsidiaries. All rights reserved.	*
+ *								*
+ * Copyright (c) 2018-2025 YottaDB LLC and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
+ *	This source code contains the intellectual property	*
+ *	of its copyright holder(s), and is made available	*
+ *	under a license.  If you do not know the terms of	*
+ *	the license, please stop and do not read further.	*
+ *								*
+ ****************************************************************/
+
+//kt added (created) this header file to achieve compilation
+
+#ifndef UTIL_OUTPUT_H
+#define UTIL_OUTPUT_H
+
+#include <stdarg.h>  // For va_list
+#include <sys/types.h>  // For caddr_t
+#include "gtm_common_defs.h"  // For boolean_t
+
+// Function declarations
+caddr_t util_format(caddr_t message, va_list fao, caddr_t buff, ssize_t size, int faocnt);
+void util_out_close(void);
+void util_out_send_oper(char *addr, unsigned int len);
+void util_out_print_vaparm(caddr_t message, int flush, va_list var, int faocnt);
+void util_out_print(caddr_t message, int flush, ...);
+void util_out_print_args(caddr_t message, int faocnt, int flush, ...);
+boolean_t util_out_save(char *dst, int *dstlen_ptr);
+void util_cond_flush(void);
+
+#ifdef DEBUG
+void util_out_syslog_dump(void);
+#endif
+
+#endif // UTIL_OUTPUT_H

--- a/sr_unix/zshow_devices.c
+++ b/sr_unix/zshow_devices.c
@@ -256,29 +256,34 @@ void zshow_devices(zshow_out *output)
 						ZS_ONE_OUT(&v, rparen_text);
 						ZS_ONE_OUT(&v, space_text);
 					}
-					if ((int4)(tt_ptr->term_ctrl) & TRM_NOECHO)
+					//kt original line --> if ((int4)(tt_ptr->term_ctrl) & TRM_NOECHO)
+					if (tt_ptr->io_state.devparam_echo == FALSE)  //kt mod.
 					{
 						ZS_PARM_SP(&v, zshow_noecho);
 					}
-					if (tt_ptr->term_ctrl & TRM_PASTHRU)
+					//kt original --> if ((tt_ptr->term_ctrl & TRM_PASTHRU)  //kt mod.
+					if (tt_ptr->io_state.passthru == TRUE)  //kt mod.
 					{
 						ZS_PARM_SP(&v, zshow_past);
 					} else
 					{
 						ZS_PARM_SP(&v, zshow_nopast);
 					}
-					if (!(tt_ptr->term_ctrl & TRM_ESCAPE))
+					//kt original --> if (!(tt_ptr->term_ctrl & TRM_ESCAPE))
+					if (!(tt_ptr->io_state.escape_processing))  //kt mod.
 					{
 						ZS_PARM_SP(&v, zshow_noesca);
 					}
-					if (tt_ptr->term_ctrl & TRM_READSYNC)
+					//kt original --> if (tt_ptr->term_ctrl & TRM_READSYNC)
+					if (tt_ptr->io_state.readsync == TRUE)  //kt mod.
 					{
 						ZS_PARM_SP(&v, zshow_reads);
 					} else
 					{
 						ZS_PARM_SP(&v, zshow_noreads);
 					}
-					if (tt_ptr->term_ctrl & TRM_NOTYPEAHD)
+					//kt original --> if (tt_ptr->term_ctrl & TRM_NOTYPEAHD)
+					if (tt_ptr->io_state.no_type_ahead)  //kt mod
 					{
 						ZS_PARM_SP(&v, zshow_notype);
 					} else
@@ -289,8 +294,8 @@ void zshow_devices(zshow_out *output)
 					{
 						ZS_PARM_SP(&v, zshow_nowrap);
 					}
-					mask_out = &tt_ptr->mask_term;
-					if (!tt_ptr->default_mask_term)
+					mask_out = &tt_ptr->io_state.mask_term;  //kt mod.  Added 'io_state.'
+					if (!tt_ptr->io_state.default_mask_term)  //kt mod.  Added 'io_state.'
 					{
 						ZS_PARM_EQU(&v, zshow_term);
 						ZS_STR_OUT(&v,dollarc_text);
@@ -345,13 +350,16 @@ void zshow_devices(zshow_out *output)
 							ZS_ONE_OUT(&v,rparen_text);
 						ZS_ONE_OUT(&v, space_text);
 					}
-					if (TT_EDITING & tt_ptr->ext_cap)
+					//kt original --> if (TT_EDITING & tt_ptr->ext_cap)
+					if BIT_FLAG_IS_ON(TT_EDITING, tt_ptr->io_state.ext_cap) //kt mod
 						ZS_PARM_SP(&v, zshow_edit);
-					if (TT_NOINSERT & tt_ptr->ext_cap)
+					//kt original --> if (TT_NOINSERT & tt_ptr->ext_cap)
+					if BIT_FLAG_IS_ON(TT_NOINSERT, tt_ptr->io_state.ext_cap) //kt mod
 						ZS_PARM_SP(&v, zshow_noinse);
-					if (TT_EMPTERM & tt_ptr->ext_cap)
+					//kt original --> if (TT_EMPTERM & tt_ptr->ext_cap)
+					if BIT_FLAG_IS_ON(TT_EMPTERM, tt_ptr->io_state.ext_cap)  //kt mod.
 						ZS_PARM_SP(&v, zshow_empterm);
-					if (tt_ptr->canonical)
+					if (tt_ptr->io_state.canonical)	//kt mod.  Added 'io_state.'
 						ZS_STR_OUT(&v, "CANONICAL ");
 					switch(tiod->ichset)
 					{
@@ -389,16 +397,19 @@ void zshow_devices(zshow_out *output)
 						ZS_STR_OUT(&v, interrupt_text);
 					if (hup_on)
 						ZS_STR_OUT(&v, hup_text);
-					if (tt_ptr->ttio_struct->c_iflag & IXON)
+					//kt original --> if (tt_ptr->ttio_struct->c_iflag & IXON)
+					if (tt_ptr->io_state.ttsync)  //kt mod Added 'io_state.' and changed to io_state.ttsync holding state.
 						ZS_PARM_SP(&v, zshow_ttsy);
 					else
 						ZS_PARM_SP(&v, zshow_nottsy);
-					if (tt_ptr->ttio_struct->c_iflag & IXOFF)
+					//kt original --> if (tt_ptr->ttio_struct->c_iflag & IXOFF)
+					if (tt_ptr->io_state.hostsync)  //kt mod Added 'io_state.' and changed to io_state.hostsync holding state.
 						ZS_PARM_SP(&v, zshow_host);
 					else
 						ZS_PARM_SP(&v, zshow_nohost);
 					/* CONVERT is like HUPENABLE which only show up when enable it */
-					if (tt_ptr->term_ctrl & TRM_CONVERT)
+					//kt original --> if (tt_ptr->term_ctrl & TRM_CONVERT)
+					if (tt_ptr->io_state.case_convert)    //kt mod Added 'io_state.' and change .case_convert to holding state.
 						ZS_PARM_SP(&v, zshow_conv);
 					break;
 				case rm:


### PR DESCRIPTION
- corrected issue whereby IO state was not properly maintained between commands
- corrected issue where NOECHO was not working properly
- added functionality such that with ESCAPE processing ON, if user types isolated ESC, then 100 ms timeout allows return of isolated ESC rather than hanging IO waiting for rest of non-existent escape sequence
- Worked to optimize TTY code readability, simplifying some boolean logic through #define MACROS

