### PR TITLE
Bug fixes of TTY IO system.  

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,16 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c17",
+            "cppStandard": "gnu++17",
+            "intelliSenseMode": "linux-gcc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,89 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug yottadb",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/yottadb", // Path to yottadb executable
+            "args": ["-dir"], // Command-line arguments for yottadb
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}", // Working directory for the debugger
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb", // Or debugger's path
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "build" // Matches the label of build task in tasks.json
+        },
+        {
+            "name": "Debug DSE",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/dse", // Path to dse executable
+            "args": [], // Command-line arguments for dse
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}", // Working directory for the debugger
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb", // Or debugger's path
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "build" // Matches the label of build task in tasks.json
+        },
+        {
+            "name": "Debug LKE",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/lke", // Path to lke executable
+            "args": [], // Command-line arguments for dse
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}", // Working directory for the debugger
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb", // Or debugger's path
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "build" // Matches the label of build task in tasks.json
+        },
+        {
+            "name": "Debug mupip",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/mupip", // Path to mupip executable
+            "args": [], // Command-line arguments for mupip
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}", // Working directory for the debugger
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb", // Or debugger's path
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "build" // Matches the label of your build task in tasks.json
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+        "files.associations": {
+                "errno.h": "c",
+                "io.h": "c",
+                "gtm_termios.h": "c",
+                "gtm_threadgbl.h": "c",
+                "gtm_threadgbl_deftypes.h": "c",
+                "mdef.h": "c",
+                "gtm_signal.h": "c",
+                "gtm_unistd.h": "c",
+                "io_params.h": "c",
+                "signal.h": "c",
+                "functional": "c",
+                "iott_open.h": "c",
+                "eintr_wrappers.h": "c",
+                "send_msg.h": "c",
+                "stringpool.h": "c",
+                "util_output.h": "c",
+                "release_name.h": "c",
+                "trmdef.h": "c",
+                "util.h": "c"
+        }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,50 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "cmake",
+      "type": "shell",
+      "command": "cmake",
+      "args": [
+        "-D",
+        "CMAKE_BUILD_TYPE=Debug",
+        ".."
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/build"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "build",
+      "type": "shell",
+      "command": "make",
+      "args": [
+        "-j",
+        "${env:NUMBER_OF_PROCESSORS}" // or "$(getconf _NPROCESSORS_ONLN)" if you prefer
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/build"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "dependsOn": "cmake",
+      "problemMatcher": ["$gcc"]
+    },
+    {
+      "label": "install",
+      "type": "shell",
+      "command": "make",
+      "args": [
+        "install"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/build"
+      },
+      "problemMatcher": []
+    }
+  ]
+}
+

--- a/sr_port/io_init.c
+++ b/sr_port/io_init.c
@@ -35,6 +35,7 @@ GBLREF io_log_name	*dollar_principal;	/* pointer to log name GTM$PRINCIPAL if de
 GBLREF io_pair		io_curr_device;		/* current device	*/
 GBLREF io_pair		io_std_device;		/* standard device	*/
 GBLREF mstr		gtm_principal, sys_input, sys_output;
+GBLREF enum gtmImageTypes	image_type;   		//kt added
 
 LITREF	mval	literal_zero;
 
@@ -59,6 +60,18 @@ static readonly unsigned char	shr_params[] =
 {
 	(unsigned char)iop_shared,
 	(unsigned char)iop_readonly,
+	(unsigned char)iop_eol
+};
+static readonly unsigned char tty_nocanonical_open_params_list[] =    //kt added entire list
+{
+	(unsigned char)iop_nocanonical,
+	(unsigned char)iop_echo,
+	(unsigned char)iop_eol
+};
+static readonly unsigned char tty_canonical_open_params_list[] =    //kt added entire list
+{
+	(unsigned char)iop_canonical,
+	(unsigned char)iop_echo,
 	(unsigned char)iop_eol
 };
 
@@ -222,6 +235,20 @@ void io_init(boolean_t term_ctrl)
 		pars.str.len = SIZEOF(nowrap_params_list);
 		pars.str.addr = (char *)nowrap_params_list;
 	}
+	else if (tt == dev_type)    //kt added this block to initialize TTY (terminal) type devices
+	{
+		if (GTM_IMAGE == image_type)
+		{
+			pars.str.len = SIZEOF(tty_nocanonical_open_params_list);
+			pars.str.addr = (char *)tty_nocanonical_open_params_list;
+		} else
+		{
+			pars.str.len = SIZEOF(tty_canonical_open_params_list);
+			pars.str.addr = (char *)tty_canonical_open_params_list;
+
+		}
+	}
+
 	val.str.len = io_curr_device.in->trans_name->len;
 	val.str.addr = io_std_device.in->trans_name->dollar_io;
 	op_use(&val, &pars);

--- a/sr_port/io_init.c
+++ b/sr_port/io_init.c
@@ -35,7 +35,7 @@ GBLREF io_log_name	*dollar_principal;	/* pointer to log name GTM$PRINCIPAL if de
 GBLREF io_pair		io_curr_device;		/* current device	*/
 GBLREF io_pair		io_std_device;		/* standard device	*/
 GBLREF mstr		gtm_principal, sys_input, sys_output;
-GBLREF enum gtmImageTypes	image_type;   		//kt added
+GBLREF enum gtmImageTypes	image_type;
 
 LITREF	mval	literal_zero;
 
@@ -62,13 +62,13 @@ static readonly unsigned char	shr_params[] =
 	(unsigned char)iop_readonly,
 	(unsigned char)iop_eol
 };
-static readonly unsigned char tty_nocanonical_open_params_list[] =    //kt added entire list
+static readonly unsigned char tty_nocanonical_open_params_list[] =    //list for initializing TTY device
 {
 	(unsigned char)iop_nocanonical,
 	(unsigned char)iop_echo,
 	(unsigned char)iop_eol
 };
-static readonly unsigned char tty_canonical_open_params_list[] =    //kt added entire list
+static readonly unsigned char tty_canonical_open_params_list[] =    //list for initializing TTY device
 {
 	(unsigned char)iop_canonical,
 	(unsigned char)iop_echo,
@@ -235,7 +235,7 @@ void io_init(boolean_t term_ctrl)
 		pars.str.len = SIZEOF(nowrap_params_list);
 		pars.str.addr = (char *)nowrap_params_list;
 	}
-	else if (tt == dev_type)    //kt added this block to initialize TTY (terminal) type devices
+	else if (tt == dev_type)    //initialize TTY (terminal) type devices
 	{
 		if (GTM_IMAGE == image_type)
 		{

--- a/sr_unix/dm_read.c
+++ b/sr_unix/dm_read.c
@@ -215,12 +215,12 @@ void	dm_read (mval *v)
 	int		outlen;			/* total characters in line so far */
 	int		match_length, msk_in, msk_num, right, selstat, status, up, home, end;
 	int		utf8_more = 0, utf8_seen;
-	boolean_t	echo_mode;  			//kt local alias
-	ttio_state* 	dm_io_state_ptr;  		//kt Will really be same as &(tt_ptr->direct_mode_io_state)
-	boolean_t	char_is_terminator;		//kt added
-	boolean_t	char_is_special_terminator;	//kt added
-	boolean_t	char_is_erase;			//kt added
-	boolean_t	char_is_backspace;		//kt added
+	boolean_t	echo_mode;
+	ttio_state* 	dm_io_state_ptr;  		//Will really be same as &(tt_ptr->direct_mode_io_state)
+	boolean_t	char_is_terminator;
+	boolean_t	char_is_special_terminator;
+	boolean_t	char_is_erase;
+	boolean_t	char_is_backspace;
 	io_desc 	*io_ptr;
 	io_termmask	mask_term;
 	mv_stent	*mvc, *mv_zintdev;
@@ -251,16 +251,16 @@ void	dm_read (mval *v)
 	active_device = io_curr_device.in;
 	io_ptr = io_curr_device.in;
 	tt_ptr = (d_tt_struct *)(io_ptr->dev_sp);
-	dm_io_state_ptr = iott_setterm_for_direct_mode(io_ptr); //kt added.  For direct mode, we want IO to be in a safe state.  E.g. if NOECHO, we still want user typing to show.
+	dm_io_state_ptr = iott_setterm_for_direct_mode(io_ptr); //For direct mode, we want IO to be in a safe state.  E.g. if NOECHO, we still want user typing to show.
 	assert (io_ptr->state == dev_open);
 	if (tt == io_curr_device.out->type)
 		iott_flush(io_curr_device.out);
-	insert_mode = !(TT_NOINSERT & dm_io_state_ptr->ext_cap);  //kt mod
+	insert_mode = !(TT_NOINSERT & dm_io_state_ptr->ext_cap);
 	utf8_active = gtm_utf8_mode ? (CHSET_M != io_ptr->ichset) : FALSE;
 	length = tt_ptr->in_buf_sz + ESC_LEN;	/* for possible escape sequence */
 	exp_length = utf8_active ? (uint4)((SIZEOF(wint_t) * length) + (GTM_MB_LEN_MAX * length) + SIZEOF(gtm_int64_t)) : length;
 	zint_restart = FALSE;
-	echo_mode = dm_io_state_ptr->ydb_echo; //kt
+	echo_mode = dm_io_state_ptr->ydb_echo;
 	if (tt_ptr->mupintr)
 	{	/* restore state to before job interrupt */
 		tt_state = &tt_ptr->tt_state_save;
@@ -338,10 +338,10 @@ void	dm_read (mval *v)
 	}
 	if (dmterm_default)
 	{	/* $view("DMTERM") or ydb_dmterm is set. Ignore the customized terminators; use the default terinators */
-		iott_set_mask_term_conditional(io_ptr, &mask_term, utf8_active, FALSE);  //kt
+		iott_set_mask_term_conditional(io_ptr, &mask_term, utf8_active, FALSE);
 	} else
-		mask_term = dm_io_state_ptr->mask_term;  //kt mod.
-	TURN_MASK_BIT_OFF(mask_term.mask, ESC);  //kt mod
+		mask_term = dm_io_state_ptr->mask_term;
+	TURN_MASK_BIT_OFF(mask_term.mask, ESC);
 	ioptr_width = io_ptr->width;
 	if (!zint_restart)
 	{
@@ -433,7 +433,7 @@ void	dm_read (mval *v)
 			if (EINTR != errno)
 			{	/* If error was EINTR, go to the top of the loop to check for outofband. */
 				HANDLE_EINTR_OUTSIDE_SYSTEM_CALL;
-				dm_io_state_ptr->discard_lf = FALSE;  //kt mod.
+				dm_io_state_ptr->discard_lf = FALSE;
 				io_ptr->dollar.za = ZA_IO_ERR;
 				rts_error_csa(CSA_ARG(NULL) VARLSTCNT(1) errno);
 			} else
@@ -445,7 +445,7 @@ void	dm_read (mval *v)
 		{	/* poll() says there's something to read, but read() found zero characters; assume connection dropped. */
 			HANDLE_EINTR_OUTSIDE_SYSTEM_CALL;
 			ISSUE_NOPRINCIO_IF_NEEDED(io_ptr, FALSE, FALSE);		/* FALSE, FALSE: READ tt not socket */
-			dm_io_state_ptr->discard_lf = FALSE;  		//kt mod
+			dm_io_state_ptr->discard_lf = FALSE;
 			RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(1) ERR_IOEOF);
 		} else if (0 < status)
 		{
@@ -455,9 +455,9 @@ void	dm_read (mval *v)
 #			ifdef UTF8_SUPPORTED
 			if (utf8_active)
 			{
-				if (dm_io_state_ptr->discard_lf)   //kt
+				if (dm_io_state_ptr->discard_lf)
 				{	/* saw CR last time so ignore following LF */
-					dm_io_state_ptr->discard_lf = FALSE;  //kt
+					dm_io_state_ptr->discard_lf = FALSE;
 					if (NATIVE_LF == inbyte)
 						continue;
 				}
@@ -512,32 +512,32 @@ void	dm_read (mval *v)
 					if (BOM_CODEPOINT == inchar)
 						continue;
 				}
-				if (dm_io_state_ptr->case_convert)  			//kt mod
+				if (dm_io_state_ptr->case_convert)
 					inchar = u_toupper(inchar);
 				GTM_IO_WCWIDTH(inchar, inchar_width);
 			} else
 			{
 #			endif
-				if (dm_io_state_ptr->case_convert)  			//kt mod
+				if (dm_io_state_ptr->case_convert)
 					NATIVE_CVT2UPPER(inbyte, inbyte);
 				inchar = inbyte;
 #			ifdef UTF8_SUPPORTED
 			}
 #			endif
 			GETASCII(asc_inchar,inchar);
-			if ((dx >= ioptr_width) && io_ptr->wrap && echo_mode)  		//kt mod
+			if ((dx >= ioptr_width) && io_ptr->wrap && echo_mode)
 			{
 				DOWRITE(tt_ptr->fildes, NATIVE_TTEOL, strlen(NATIVE_TTEOL));	/* BYPASSOK */
 				dx = 0;
 			}
 			terminator_seen = FALSE;
-			char_is_terminator = IS_TERMINATOR(mask_term.mask, INPUT_CHAR, utf8_active);  //kt
+			char_is_terminator = IS_TERMINATOR(mask_term.mask, INPUT_CHAR, utf8_active);
 			//Below, UTF and default terminators and UTF terminators above ASCII_MAX
 			char_is_special_terminator = IS_SPECIAL_TERMINATOR(INPUT_CHAR, utf8_active);
-			if (char_is_terminator) //kt mod
+			if (char_is_terminator)
 			{
 				terminator_seen = TRUE;
-			} else if (char_is_special_terminator && dm_io_state_ptr->default_mask_term)  //kt
+			} else if (char_is_special_terminator && dm_io_state_ptr->default_mask_term)
 			{
 				terminator_seen = TRUE;
 			}
@@ -547,7 +547,7 @@ void	dm_read (mval *v)
 				STORE_OFF(0, outlen);
 				err_recall = NO_ERROR;
 				if (utf8_active && (ASCII_CR == INPUT_CHAR))
-					dm_io_state_ptr->discard_lf = TRUE;  		//kt mod
+					dm_io_state_ptr->discard_lf = TRUE;
 					/* exceeding the maximum length exits the while loop, so it must fit here . */
 #				ifdef UTF8_SUPPORTED
 				if (utf8_active)
@@ -679,9 +679,9 @@ void	dm_read (mval *v)
 				}
 				continue;	/* to allow more input */
 			}
-			char_is_erase = ((int)inchar == dm_io_state_ptr->ttio_struct.c_cc[VERASE]) ;	//kt added
-			char_is_backspace = ((NULL != KEY_BACKSPACE) && ('\0' == KEY_BACKSPACE[1]) && (inchar == KEY_BACKSPACE[0])); 	 //kt added
-			if ( (dm_io_state_ptr->passthru == FALSE ) && (char_is_erase || char_is_backspace) )  //kt mod
+			char_is_erase = ((int)inchar == dm_io_state_ptr->ttio_struct.c_cc[VERASE]) ;
+			char_is_backspace = ((NULL != KEY_BACKSPACE) && ('\0' == KEY_BACKSPACE[1]) && (inchar == KEY_BACKSPACE[0]));
+			if ( (dm_io_state_ptr->passthru == FALSE ) && (char_is_erase || char_is_backspace) )
 			{
 				if (0 < instr)
 				{
@@ -896,7 +896,7 @@ void	dm_read (mval *v)
 					if (0 != instr)
 						write_str(BUFF_ADDR(0), instr, dx_start, TRUE, FALSE);
 				}
-			} else if (echo_mode)  //kt mod
+			} else if (echo_mode)
 			{
 				if (instr != outlen)
 				{
@@ -954,7 +954,7 @@ void	dm_read (mval *v)
 		if (IS_AT_END_OF_STRINGPOOL(buffer_start, 0))
 			stringpool.free += v->str.len;	/* otherwise using space from before interrupt */
 	}
-	if (echo_mode)  //kt mod
+	if (echo_mode)
 	{
 		if ((io_ptr->dollar.x += dx_outlen) >= ioptr_width && io_ptr->wrap)
 		{
@@ -967,6 +967,6 @@ void	dm_read (mval *v)
 		}
 	}
 	active_device = 0;
-	//kt not needed --> RESETTERM_IF_NEEDED(io_ptr, EXPECT_SETTERM_DONE_TRUE);
+	//not needed --> RESETTERM_IF_NEEDED(io_ptr, EXPECT_SETTERM_DONE_TRUE);
 	return;
 }

--- a/sr_unix/dm_read.c
+++ b/sr_unix/dm_read.c
@@ -215,11 +215,16 @@ void	dm_read (mval *v)
 	int		outlen;			/* total characters in line so far */
 	int		match_length, msk_in, msk_num, right, selstat, status, up, home, end;
 	int		utf8_more = 0, utf8_seen;
+	boolean_t	echo_mode;  			//kt local alias
+	ttio_state* 	dm_io_state_ptr;  		//kt Will really be same as &(tt_ptr->direct_mode_io_state)
+	boolean_t	char_is_terminator;		//kt added
+	boolean_t	char_is_special_terminator;	//kt added
+	boolean_t	char_is_erase;			//kt added
+	boolean_t	char_is_backspace;		//kt added
 	io_desc 	*io_ptr;
 	io_termmask	mask_term;
 	mv_stent	*mvc, *mv_zintdev;
 	tt_interrupt	*tt_state;
-	uint4		mask;
 	unsigned int	exp_length, len, length;
 	unsigned char	*buffer_start;		/* beginning of non UTF8 buffer */
 	unsigned char	escape_sequence[ESC_LEN];
@@ -246,15 +251,16 @@ void	dm_read (mval *v)
 	active_device = io_curr_device.in;
 	io_ptr = io_curr_device.in;
 	tt_ptr = (d_tt_struct *)(io_ptr->dev_sp);
-	SETTERM_IF_NEEDED(io_ptr, tt_ptr);
+	dm_io_state_ptr = iott_setterm_for_direct_mode(io_ptr); //kt added.  For direct mode, we want IO to be in a safe state.  E.g. if NOECHO, we still want user typing to show.
 	assert (io_ptr->state == dev_open);
 	if (tt == io_curr_device.out->type)
 		iott_flush(io_curr_device.out);
-	insert_mode = !(TT_NOINSERT & tt_ptr->ext_cap);
+	insert_mode = !(TT_NOINSERT & dm_io_state_ptr->ext_cap);  //kt mod
 	utf8_active = gtm_utf8_mode ? (CHSET_M != io_ptr->ichset) : FALSE;
 	length = tt_ptr->in_buf_sz + ESC_LEN;	/* for possible escape sequence */
 	exp_length = utf8_active ? (uint4)((SIZEOF(wint_t) * length) + (GTM_MB_LEN_MAX * length) + SIZEOF(gtm_int64_t)) : length;
 	zint_restart = FALSE;
+	echo_mode = dm_io_state_ptr->ydb_echo; //kt
 	if (tt_ptr->mupintr)
 	{	/* restore state to before job interrupt */
 		tt_state = &tt_ptr->tt_state_save;
@@ -330,19 +336,12 @@ void	dm_read (mval *v)
 		index = 0;
 		cl = clmod(comline_index - index);
 	}
-	mask = tt_ptr->term_ctrl;
 	if (dmterm_default)
 	{	/* $view("DMTERM") or ydb_dmterm is set. Ignore the customized terminators; use the default terinators */
-		memset(&mask_term.mask[0], 0, SIZEOF(io_termmask));
-		if (utf8_active)
-		{
-			mask_term.mask[0] = TERM_MSK_UTF8_0;
-			mask_term.mask[4] = TERM_MSK_UTF8_4;
-		} else
-			mask_term.mask[0] = TERM_MSK;
+		iott_set_mask_term_conditional(io_ptr, &mask_term, utf8_active, FALSE);  //kt
 	} else
-		mask_term = tt_ptr->mask_term;
-	mask_term.mask[ESC / NUM_BITS_IN_INT4] &= ~(1 << ESC);
+		mask_term = dm_io_state_ptr->mask_term;  //kt mod.
+	TURN_MASK_BIT_OFF(mask_term.mask, ESC);  //kt mod
 	ioptr_width = io_ptr->width;
 	if (!zint_restart)
 	{
@@ -434,7 +433,7 @@ void	dm_read (mval *v)
 			if (EINTR != errno)
 			{	/* If error was EINTR, go to the top of the loop to check for outofband. */
 				HANDLE_EINTR_OUTSIDE_SYSTEM_CALL;
-				tt_ptr->discard_lf = FALSE;
+				dm_io_state_ptr->discard_lf = FALSE;  //kt mod.
 				io_ptr->dollar.za = ZA_IO_ERR;
 				rts_error_csa(CSA_ARG(NULL) VARLSTCNT(1) errno);
 			} else
@@ -446,7 +445,7 @@ void	dm_read (mval *v)
 		{	/* poll() says there's something to read, but read() found zero characters; assume connection dropped. */
 			HANDLE_EINTR_OUTSIDE_SYSTEM_CALL;
 			ISSUE_NOPRINCIO_IF_NEEDED(io_ptr, FALSE, FALSE);		/* FALSE, FALSE: READ tt not socket */
-			tt_ptr->discard_lf = FALSE;
+			dm_io_state_ptr->discard_lf = FALSE;  		//kt mod
 			RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(1) ERR_IOEOF);
 		} else if (0 < status)
 		{
@@ -456,9 +455,9 @@ void	dm_read (mval *v)
 #			ifdef UTF8_SUPPORTED
 			if (utf8_active)
 			{
-				if (tt_ptr->discard_lf)
+				if (dm_io_state_ptr->discard_lf)   //kt
 				{	/* saw CR last time so ignore following LF */
-					tt_ptr->discard_lf = FALSE;
+					dm_io_state_ptr->discard_lf = FALSE;  //kt
 					if (NATIVE_LF == inbyte)
 						continue;
 				}
@@ -513,34 +512,33 @@ void	dm_read (mval *v)
 					if (BOM_CODEPOINT == inchar)
 						continue;
 				}
-				if (mask & TRM_CONVERT)
+				if (dm_io_state_ptr->case_convert)  			//kt mod
 					inchar = u_toupper(inchar);
 				GTM_IO_WCWIDTH(inchar, inchar_width);
 			} else
 			{
 #			endif
-				if (mask & TRM_CONVERT)
+				if (dm_io_state_ptr->case_convert)  			//kt mod
 					NATIVE_CVT2UPPER(inbyte, inbyte);
 				inchar = inbyte;
 #			ifdef UTF8_SUPPORTED
 			}
 #			endif
 			GETASCII(asc_inchar,inchar);
-			if ((dx >= ioptr_width) && io_ptr->wrap && !(mask & TRM_NOECHO))
+			if ((dx >= ioptr_width) && io_ptr->wrap && echo_mode)  		//kt mod
 			{
 				DOWRITE(tt_ptr->fildes, NATIVE_TTEOL, strlen(NATIVE_TTEOL));	/* BYPASSOK */
 				dx = 0;
 			}
 			terminator_seen = FALSE;
-			if (!utf8_active || (ASCII_MAX >= INPUT_CHAR))
+			char_is_terminator = IS_TERMINATOR(mask_term.mask, INPUT_CHAR, utf8_active);  //kt
+			//Below, UTF and default terminators and UTF terminators above ASCII_MAX
+			char_is_special_terminator = IS_SPECIAL_TERMINATOR(INPUT_CHAR, utf8_active);
+			if (char_is_terminator) //kt mod
 			{
-				msk_num = (uint4)INPUT_CHAR / NUM_BITS_IN_INT4;
-				msk_in = (1 << ((uint4)INPUT_CHAR % NUM_BITS_IN_INT4));
-				if (msk_in & mask_term.mask[msk_num])
-					terminator_seen = TRUE;
-			} else if (utf8_active && tt_ptr->default_mask_term && ((INPUT_CHAR == u32_line_term[U32_LT_NL])
-				 || (INPUT_CHAR == u32_line_term[U32_LT_LS]) || (INPUT_CHAR == u32_line_term[U32_LT_PS])))
-			{	/* UTF and default terminators and UTF terminators above ASCII_MAX */
+				terminator_seen = TRUE;
+			} else if (char_is_special_terminator && dm_io_state_ptr->default_mask_term)  //kt
+			{
 				terminator_seen = TRUE;
 			}
 			if (terminator_seen)
@@ -549,7 +547,7 @@ void	dm_read (mval *v)
 				STORE_OFF(0, outlen);
 				err_recall = NO_ERROR;
 				if (utf8_active && (ASCII_CR == INPUT_CHAR))
-					tt_ptr->discard_lf = TRUE;
+					dm_io_state_ptr->discard_lf = TRUE;  		//kt mod
 					/* exceeding the maximum length exits the while loop, so it must fit here . */
 #				ifdef UTF8_SUPPORTED
 				if (utf8_active)
@@ -681,9 +679,9 @@ void	dm_read (mval *v)
 				}
 				continue;	/* to allow more input */
 			}
-			if ((((int)inchar == tt_ptr->ttio_struct->c_cc[VERASE])
-			     || (((NULL != KEY_BACKSPACE) && ('\0' == KEY_BACKSPACE[1]) && (inchar == KEY_BACKSPACE[0]))))
-			    && !(mask & TRM_PASTHRU))
+			char_is_erase = ((int)inchar == dm_io_state_ptr->ttio_struct.c_cc[VERASE]) ;	//kt added
+			char_is_backspace = ((NULL != KEY_BACKSPACE) && ('\0' == KEY_BACKSPACE[1]) && (inchar == KEY_BACKSPACE[0])); 	 //kt added
+			if ( (dm_io_state_ptr->passthru == FALSE ) && (char_is_erase || char_is_backspace) )  //kt mod
 			{
 				if (0 < instr)
 				{
@@ -898,7 +896,7 @@ void	dm_read (mval *v)
 					if (0 != instr)
 						write_str(BUFF_ADDR(0), instr, dx_start, TRUE, FALSE);
 				}
-			} else if (!(mask & TRM_NOECHO))
+			} else if (echo_mode)  //kt mod
 			{
 				if (instr != outlen)
 				{
@@ -956,7 +954,7 @@ void	dm_read (mval *v)
 		if (IS_AT_END_OF_STRINGPOOL(buffer_start, 0))
 			stringpool.free += v->str.len;	/* otherwise using space from before interrupt */
 	}
-	if (!(mask & TRM_NOECHO))
+	if (echo_mode)  //kt mod
 	{
 		if ((io_ptr->dollar.x += dx_outlen) >= ioptr_width && io_ptr->wrap)
 		{
@@ -969,6 +967,6 @@ void	dm_read (mval *v)
 		}
 	}
 	active_device = 0;
-	RESETTERM_IF_NEEDED(io_ptr, EXPECT_SETTERM_DONE_TRUE);
+	//kt not needed --> RESETTERM_IF_NEEDED(io_ptr, EXPECT_SETTERM_DONE_TRUE);
 	return;
 }

--- a/sr_unix/iott_close.c
+++ b/sr_unix/iott_close.c
@@ -54,6 +54,7 @@ void iott_close(io_desc *v, mval *pp)
 	assert((v->pair.in == v) || (v->pair.out == v));
 	ttptr = (d_tt_struct *)v->dev_sp;
 	v->state = dev_closed;
+	((d_tt_struct *)v->dev_sp)->setterm_done_by = process_id;  //kt added.  Set flag to ensure resetterm is actually done
 	iott_resetterm(v);
 
 	p_offset = 0;

--- a/sr_unix/iott_close.c
+++ b/sr_unix/iott_close.c
@@ -54,7 +54,7 @@ void iott_close(io_desc *v, mval *pp)
 	assert((v->pair.in == v) || (v->pair.out == v));
 	ttptr = (d_tt_struct *)v->dev_sp;
 	v->state = dev_closed;
-	((d_tt_struct *)v->dev_sp)->setterm_done_by = process_id;  //kt added.  Set flag to ensure resetterm is actually done
+	((d_tt_struct *)v->dev_sp)->setterm_done_by = process_id;  //Set flag to ensure resetterm is actually done
 	iott_resetterm(v);
 
 	p_offset = 0;

--- a/sr_unix/iott_open.c
+++ b/sr_unix/iott_open.c
@@ -151,7 +151,7 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 		}
 	}
 	//Compile ydb state and send this to TTY IO subsystem.  8  1 will be default time and minimum read; can be changed later.
-	iott_compile_state_and_set_tty_and_ydb_echo(ioptr, 8, 1, handle_set_tty_err_mode_3);  .
+	iott_compile_state_and_set_tty_and_ydb_echo(ioptr, 8, 1, handle_set_tty_err_mode_3);
 	if (initializing)
 	{
 		//complete setup for initial io state.

--- a/sr_unix/iott_open.c
+++ b/sr_unix/iott_open.c
@@ -63,7 +63,7 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 	gtm_chset_t	temp_chset, old_ichset;
 	boolean_t	empt = FALSE;
 	boolean_t	ch_set;
-	boolean_t	initializing = FALSE; 		//kt added
+	boolean_t	initializing = FALSE;
 	DCL_THREADGBL_ACCESS;
 
 	SETUP_THREADGBL_ACCESS;
@@ -71,7 +71,7 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 	ESTABLISH_RET_GTMIO_CH(&ioptr->pair, -1, ch_set);
 	if (ioptr->state == dev_never_opened)
 	{
-		//kt Large block change.  Putting state into separate structures, which are not a pointers....
+		//Large block change.  Putting state into separate structures, which are not a pointers....
 		//NOTE: d_tt_struct has been changed such that additional memory does not need to be allocated for ttio_struct's
 		dev_name->iod->dev_sp = (void *)malloc(SIZEOF(d_tt_struct));
 		memset(dev_name->iod->dev_sp, 0, SIZEOF(d_tt_struct)); // NOTE: by filling structure initially with 0's, this effects setting all booleans to FALSE. E.g. tt_ptr->io_state.canonical etc.
@@ -90,14 +90,14 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 		//Start setup of device, starting io_state from initial_io_state
 		//Will be further modified below.
 		tt_ptr->io_state = tt_ptr->initial_io_state;
-		//kt end mod -------------
+		//end mod -------------
 	}
 	tt_ptr = (d_tt_struct *)dev_name->iod->dev_sp;
 	if (tt_ptr->mupintr)
 		RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(1) ERR_ZINTRECURSEIO);
 	p_offset = 0;
 	old_ichset = ioptr->ichset;
-	iott_open_params_to_state(ioptr, pp, &(tt_ptr->io_state));  //kt centralizing param management to allow alternate IO states
+	iott_open_params_to_state(ioptr, pp, &(tt_ptr->io_state));  //centralizing param management to allow alternate IO states
 	if (ioptr->state != dev_open)
 	{
 		int	status;
@@ -105,7 +105,7 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 
 		assert(fd >= 0);
 		tt_ptr->fildes = fd;
-		//kt NOTE: Moved the setting of TTY attribs to below.
+		//NOTE: Moved the setting of TTY attribs to below.
 		//         In iott_compile_state_and_set_tty_and_ydb_echo(), below, tt_ptr->io_state.ttio_struct will be properly set up.
 		status = getcaps(tt_ptr->fildes);
 		if (1 != status)
@@ -127,7 +127,7 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 		ioptr->wrap = (0 == AUTO_RIGHT_MARGIN) ? FALSE : TRUE; /* defensive programming; till we are absolutely, positively
 									* certain that there are no uses of wrap == TRUE */
 		tt_ptr->tbuffp = tt_ptr->ttybuff;	/* Buffer is now empty */
-		tt_ptr->io_state.discard_lf = FALSE;  //kt
+		tt_ptr->io_state.discard_lf = FALSE;
 		if (!io_std_device.in || io_std_device.in == ioptr->pair.in)	/* io_std_device.in not set yet in io_init */
 		{	/* $PRINCIPAL */
 			tt_ptr->ext_cap = ydb_principal_editing_defaults;
@@ -137,9 +137,9 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 		if (empt)
 			tt_ptr->ext_cap |= TT_EMPTERM;
 		/* Set terminal mask on the terminal not open, if default_term or if CHSET changes */
-		if (tt_ptr->io_state.default_mask_term || (old_ichset != ioptr->ichset))  //kt
+		if (tt_ptr->io_state.default_mask_term || (old_ichset != ioptr->ichset))
 		{
-			iott_set_mask_term_conditional(ioptr, &(tt_ptr->io_state.mask_term), (CHSET_M != ioptr->ichset), TRUE);  //kt
+			iott_set_mask_term_conditional(ioptr, &(tt_ptr->io_state.mask_term), (CHSET_M != ioptr->ichset), TRUE);
 		}
 		ioptr->state = dev_open;
 	} else
@@ -147,12 +147,12 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 		/* Set terminal mask on the already open terminal, if CHSET changes */
 		if (old_ichset != ioptr->ichset)
 		{
-			iott_set_mask_term_conditional(ioptr, &(tt_ptr->io_state.mask_term), (CHSET_M != ioptr->ichset), TRUE);  //kt mod
+			iott_set_mask_term_conditional(ioptr, &(tt_ptr->io_state.mask_term), (CHSET_M != ioptr->ichset), TRUE);
 		}
 	}
 	//Compile ydb state and send this to TTY IO subsystem.  8  1 will be default time and minimum read; can be changed later.
-	iott_compile_state_and_set_tty_and_ydb_echo(ioptr, 8, 1, handle_set_tty_err_mode_3);  //kt added.
-	if (initializing)  //kt added block
+	iott_compile_state_and_set_tty_and_ydb_echo(ioptr, 8, 1, handle_set_tty_err_mode_3);  .
+	if (initializing)
 	{
 		//complete setup for initial io state.
 		iott_set_mask_term_conditional(ioptr, &(tt_ptr->initial_io_state.mask_term), (CHSET_M != ioptr->ichset), TRUE);
@@ -169,7 +169,6 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, uint8 tim
 }
 
 void iott_TTY_to_state(d_tt_struct * tt_ptr, ttio_state* an_io_state_ptr)
-//kt added function
 //Purpose: Set ydb IO state based on state of TTY IO subsystem, esp when first opening TTY IO device.
 //
 //  Why needed? Because if the TTY IO initially has echo (+) mode but no devparam specifies state of echo,
@@ -197,7 +196,6 @@ void iott_TTY_to_state(d_tt_struct * tt_ptr, ttio_state* an_io_state_ptr)
 }
 
 void iott_tio_struct_to_state(ttio_state* an_io_state_ptr, struct termios * ttio_struct_ptr)
-//kt added function
 //Purpose: Set ydb IO state based on value of a ttio_struct_ptr
 {
 	an_io_state_ptr->ttio_struct = *ttio_struct_ptr;
@@ -211,9 +209,8 @@ void iott_tio_struct_to_state(ttio_state* an_io_state_ptr, struct termios * ttio
 }
 
 void iott_open_params_to_state(io_desc* io_ptr, mval* devparms, ttio_state* io_state_ptr)
-//kt added function
-//kt NOTE: This establishes the IO state into ydb data structures, based on USE device parameters.
-//	   It does NOT write anything out to the TTY IO subsystem.
+//NOTE: This establishes the IO state into ydb data structures, based on USE device parameters.
+//      It does NOT write anything out to the TTY IO subsystem.
 {
 	d_tt_struct* 		tt_ptr;
 	DCL_THREADGBL_ACCESS;
@@ -226,7 +223,6 @@ void iott_open_params_to_state(io_desc* io_ptr, mval* devparms, ttio_state* io_s
 }
 
 boolean_t iott_is_valid_open_param(io_params_type aparam)   //is aparam valid for OPEN command?
-//kt added function
 {
 	boolean_t	result;
 	result = (	(aparam == iop_exception) 	||

--- a/sr_unix/iott_readfl.c
+++ b/sr_unix/iott_readfl.c
@@ -88,7 +88,7 @@ error_def(ERR_NOPRINCIO);
 error_def(ERR_TERMHANGUP);
 error_def(ERR_ZINTRECURSEIO);
 
-//kt
+
 #define IOTT_MOVE_START_OF_LINE(TT_PTR_FILDES, ECHO_MODE, DX, DX_INSTR, DX_START, IOPTR_WIDTH, TERM_ERROR_LINE, INSTR)	\
 MBSTART {														\
 	int	num_lines_above;											\
@@ -108,7 +108,7 @@ MBSTART {														\
 	dx = dx_start;													\
 } MBEND
 
-//kt
+
 #define IOTT_MOVE_END_OF_LINE(TT_PTR_FILDES, ECHO_MODE, DX, DX_INSTR, DX_START, DX_OUTLEN, IOPTR_WIDTH, TERM_ERROR_LINE, INSTR, OUTLEN)	\
 MBSTART {																\
 	int	num_lines_above;													\
@@ -212,13 +212,13 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 	io_termmask	mask_term;
 	mv_stent	*mvc, *mv_zintdev;
 	tt_interrupt	*tt_state;
-	boolean_t	echo_mode;  			//kt added  Local alias
-	uint4		ext_cap;  			//kt added
-	ttio_state	temp_io_state; 			//kt added
-	boolean_t	char_is_terminator;		//kt added
-	boolean_t	char_is_special_terminator; 	//kt added
-	boolean_t	char_is_erase;			//kt added
-	boolean_t	char_is_backspace;		//kt added
+	boolean_t	echo_mode;  			//Local alias
+	uint4		ext_cap;
+	ttio_state	temp_io_state;
+	boolean_t	char_is_terminator;
+	boolean_t	char_is_special_terminator;
+	boolean_t	char_is_erase;
+	boolean_t	char_is_backspace;
 	unsigned char	inbyte, *outptr, *outtop, *zb_ptr, *zb_top;
 	unsigned char	more_buf[GTM_MB_LEN_MAX + 1], *more_ptr;	/* to build up multi byte for character */
 	unsigned char	*buffer_start;		/* beginning of non UTF8 buffer */
@@ -244,22 +244,22 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 	}
 	ESTABLISH_RET_GTMIO_CH(&io_curr_device, -1, ch_set);
 	tt_ptr = (d_tt_struct *)(io_ptr->dev_sp);
-	if ((length != tt_ptr->in_buf_sz) && (tt_ptr->io_state.canonical == true))   //kt added block
+	if ((length != tt_ptr->in_buf_sz) && (tt_ptr->io_state.canonical == true))
 	{
 		//Handle situation: READ X#123  <-- i.e. read particular number of characters.
 		//NOTE: Canonical is not compatible with reading a particular number of characters, because TTY IO subsystem will hold on to all chars until a terminator (e.g. LF or CR) encountered/
-		iott_setterm_for_no_canonical(io_ptr, &temp_io_state);	//kt added.  Establishes temp_io_state for use here in this function
+		iott_setterm_for_no_canonical(io_ptr, &temp_io_state);	//Establishes temp_io_state for use here in this function
 	} else
 	{
 		SETTERM_IF_NEEDED(io_ptr, tt_ptr);
-		temp_io_state = tt_ptr->io_state;  		//kt make temp_io_state to be same as normal state.
+		temp_io_state = tt_ptr->io_state;  		//Make temp_io_state to be same as normal state.
 	}
 	assert(dev_open == io_ptr->state);
 	iott_flush(io_curr_device.out);
-	ext_cap =  temp_io_state.ext_cap; 			//kt added
-	insert_mode = BIT_FLAG_IS_OFF(TT_NOINSERT, ext_cap);	/* get initial mode */  		//kt mod
-	empterm	= BIT_FLAG_IS_ON(TT_EMPTERM, ext_cap); 							//kt mod
-	echo_mode = temp_io_state.ydb_echo; 								//kt
+	ext_cap =  temp_io_state.ext_cap;
+	insert_mode = BIT_FLAG_IS_OFF(TT_NOINSERT, ext_cap);	/* get initial mode */
+	empterm	= BIT_FLAG_IS_ON(TT_EMPTERM, ext_cap);
+	echo_mode = temp_io_state.ydb_echo;
 	ioptr_width = io_ptr->width;
 	utf8_active = gtm_utf8_mode ? (CHSET_M != io_ptr->ichset) : FALSE;
 	/* if utf8_active, need room for multi byte characters plus wint_t buffer */
@@ -364,14 +364,14 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 	}
 	v->str.len = 0;
 	ret = TRUE;
-	mask_term = temp_io_state.mask_term;						//kt mod
+	mask_term = temp_io_state.mask_term;
 	/* keep test in next line in sync with test in iott_rdone.c */
-	edit_mode = ( BIT_FLAG_IS_ON(TT_EDITING, ext_cap) && (temp_io_state.passthru == FALSE ) && echo_mode );  		//kt mod
+	edit_mode = ( BIT_FLAG_IS_ON(TT_EDITING, ext_cap) && (temp_io_state.passthru == FALSE ) && echo_mode );
 	if (!zint_restart)
 	{
-		if (temp_io_state.no_type_ahead)  					//kt mod
+		if (temp_io_state.no_type_ahead)
 			TCFLUSH(tt_ptr->fildes, TCIFLUSH, status);
-		if (temp_io_state.readsync)  						//kt mod
+		if (temp_io_state.readsync)
 		{
 			DOWRITERC(tt_ptr->fildes, &dc1, 1, status);
 			if (0 != status)
@@ -522,7 +522,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 			HANDLE_EINTR_OUTSIDE_SYSTEM_CALL;
 			/* set prin_in_dev_failure to FALSE to indicate input device is working now */
 			prin_in_dev_failure = FALSE;
-			if (temp_io_state.canonical)  //kt mod
+			if (temp_io_state.canonical)
 			{
 				if (0 == inbyte)
 				{
@@ -534,7 +534,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 					io_ptr->dollar.x = 0;
 					io_ptr->dollar.za = ZA_IO_ERR;
 					io_ptr->dollar.y++;
-					temp_io_state.discard_lf = FALSE; 		 //kt mod
+					temp_io_state.discard_lf = FALSE;
 					if (io_ptr->error_handler.len > 0)
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(1) ERR_IOEOF);
 					break;
@@ -544,9 +544,9 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 #ifdef UTF8_SUPPORTED
 			if (utf8_active)
 			{
-				if (temp_io_state.discard_lf)  				//kt mod
+				if (temp_io_state.discard_lf)
 				{	/* saw CR last time so ignore following LF */
-					temp_io_state.discard_lf = FALSE; 		 //kt mod
+					temp_io_state.discard_lf = FALSE;
 					if (NATIVE_LF == inbyte)
 						continue;
 				}
@@ -608,13 +608,13 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 					if (BOM_CODEPOINT == inchar)
 						continue;
 				}
-				if (temp_io_state.case_convert)  		//kt mod
+				if (temp_io_state.case_convert)
 					inchar = u_toupper(inchar);
 				GTM_IO_WCWIDTH(inchar, inchar_width);
 			} else
 			{
 #endif
-				if (temp_io_state.case_convert)  		//kt mod
+				if (temp_io_state.case_convert)
 					NATIVE_CVT2UPPER(inbyte, inbyte);
 				inchar = inbyte;
 				inchar_width = 1;
@@ -622,7 +622,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 			}
 #endif
 			GETASCII(asc_inchar,inchar);
-			if ( !edit_mode && (dx >= ioptr_width) && io_ptr->wrap && echo_mode )  //kt mod
+			if ( !edit_mode && (dx >= ioptr_width) && io_ptr->wrap && echo_mode )
 			{
 				DOWRITE(tt_ptr->fildes, NATIVE_TTEOL, STRLEN(NATIVE_TTEOL));
 				dx = 0;
@@ -639,7 +639,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 				async_action(FALSE);
 				break;
 			}
-			if (((temp_io_state.escape_processing) || edit_mode)  			//kt mod
+			if (((temp_io_state.escape_processing) || edit_mode)
 			     && ((NATIVE_ESC == inchar) || (START != io_ptr->esc_state)))
 			{
 				if (zb_ptr >= zb_top UTF8_ONLY(|| (utf8_active && ASCII_MAX < inchar)))
@@ -665,13 +665,13 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 			{
 				char_is_terminator = IS_TERMINATOR(mask_term.mask, INPUT_CHAR, utf8_active);
 				char_is_special_terminator = IS_SPECIAL_TERMINATOR(INPUT_CHAR, utf8_active);
-				if (char_is_terminator)	   //kt mod
+				if (char_is_terminator)
 				{
 					*zb_ptr++ = (unsigned char)INPUT_CHAR;
 					if (utf8_active && ASCII_CR == INPUT_CHAR)
-						temp_io_state.discard_lf = TRUE;  //kt mod
+						temp_io_state.discard_lf = TRUE;
 					break;
-				} else if (char_is_special_terminator && temp_io_state.default_mask_term)  //kt
+				} else if (char_is_special_terminator && temp_io_state.default_mask_term)
 				{	/* UTF and default terminators and UTF terminators above ASCII_MAX */
 					zb_ptr = UTF8_WCTOMB(INPUT_CHAR, zb_ptr);
 					break;
@@ -681,10 +681,10 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 				assert(outlen >= instr);
 				/* For most of the terminal the 'kbs' string capability is a byte in length. It means that it is
 				  Not treated as escape sequence. So explicitly check if the input corresponds to the 'kbs' */
-				char_is_erase = ((int)inchar == temp_io_state.ttio_struct.c_cc[VERASE]) ;	//kt added
-				char_is_backspace = ((NULL != KEY_BACKSPACE) && ('\0' == KEY_BACKSPACE[1]) && (inchar == KEY_BACKSPACE[0])); 	//kt added
+				char_is_erase = ((int)inchar == temp_io_state.ttio_struct.c_cc[VERASE]) ;
+				char_is_backspace = ((NULL != KEY_BACKSPACE) && ('\0' == KEY_BACKSPACE[1]) && (inchar == KEY_BACKSPACE[0]));
 				if ( ( temp_io_state.passthru == FALSE ) &&
-				     ( char_is_erase || (empterm && char_is_backspace) ) )  //kt mod
+				     ( char_is_erase || (empterm && char_is_backspace) ) )
 				{
 					if (0 < instr && (edit_mode || 0 < dx))
 					{
@@ -692,7 +692,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 						delchar_width = dx_instr - dx_prev;
 						if (edit_mode)
 						{
-							if (echo_mode)  					//kt
+							if (echo_mode)
 								move_cursor_left(dx, delchar_width);
 							dx = (dx - delchar_width + ioptr_width) % ioptr_width;
 						} else
@@ -701,12 +701,12 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 						dx_instr -= delchar_width;
 						STORE_OFF(' ', outlen);
 						outlen--;
-						if (echo_mode && edit_mode)  					//kt
+						if (echo_mode && edit_mode)
 						{
 							IOTT_COMBINED_CHAR_CHECK;
 						}
 						MOVE_BUFF(instr, BUFF_ADDR(instr + 1), outlen - instr);
-						if (echo_mode)  						//kt
+						if (echo_mode)
 						{
 							if (!edit_mode)
 							{
@@ -750,12 +750,12 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 					{
 						case EDIT_SOL:	/* ctrl A  start of line */
 						{
-							IOTT_MOVE_START_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, ioptr_width, term_error_line, instr);  //kt
+							IOTT_MOVE_START_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, ioptr_width, term_error_line, instr);
 							break;
 						}
 						case EDIT_EOL:	/* ctrl E  end of line */
 						{
-							IOTT_MOVE_END_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, dx_outlen, ioptr_width, term_error_line, instr, outlen);  //kt
+							IOTT_MOVE_END_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, dx_outlen, ioptr_width, term_error_line, instr, outlen);
 							break;
 						}
 						case EDIT_LEFT:	/* ctrl B  left one */
@@ -765,7 +765,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 								dx_prev = compute_dx(BUFF_ADDR(0), instr - 1,
 												ioptr_width, dx_start);
 								inchar_width = dx_instr - dx_prev;
-								if (echo_mode)  //kt mod
+								if (echo_mode)
 								{
 									if (0 != move_cursor_left(dx, inchar_width))
 									{
@@ -786,7 +786,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 								dx_next = compute_dx(BUFF_ADDR(0), instr + 1,
 												ioptr_width, dx_start);
 								inchar_width = dx_next - dx_instr;
-								if (echo_mode)  //kt mod
+								if (echo_mode)
 								{
 									if (0 != move_cursor_right(dx, inchar_width))
 									{
@@ -802,7 +802,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 						}
 						case EDIT_DEOL:	/* ctrl K  delete to end of line */
 						{
-							if (echo_mode)  //kt mod
+							if (echo_mode)
 							{
 								if (0 != write_str_spaces(dx_outlen - dx_instr, dx, FALSE))
 								{
@@ -824,7 +824,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 											ioptr_width;
 							num_chars_left = dx - dx_start;
 							SET_BUFF(0, ' ', outlen);
-							if (echo_mode)  //kt mod
+							if (echo_mode)
 							{
 								status = move_cursor(tt_ptr->fildes,
 									num_lines_above, num_chars_left);
@@ -847,12 +847,12 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 							{
 								STORE_OFF(' ', outlen);
 								outlen--;
-								if (echo_mode)  //kt mod
+								if (echo_mode)
 								{
 									IOTT_COMBINED_CHAR_CHECK;
 								}
 								MOVE_BUFF(instr, BUFF_ADDR(instr + 1), outlen - instr);
-								if (echo_mode)  //kt mod
+								if (echo_mode)
 								{	/* First write spaces on all the display columns that
 									 * the current string occupied. Then overwrite that
 									 * with the new string. This way we are guaranteed all
@@ -887,7 +887,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 								}
 							}
 							STORE_OFF(inchar, instr);
-							if (echo_mode)  //kt mod
+							if (echo_mode)
 							{
 								if (!edit_mode)
 								{
@@ -933,7 +933,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 							{	/* Compute value of dollarx at the new cursor position */
 								dx_cur = compute_dx(BUFF_ADDR(0), instr, ioptr_width, dx_start);
 								inchar_width = dx_cur - dx_instr;
-								if (echo_mode)  //kt mod
+								if (echo_mode)
 								{
 									term_error_line = __LINE__;
 									status = move_cursor_right(dx, inchar_width);
@@ -1033,7 +1033,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 				{	/* Move one character to the left */
 					dx_prev = compute_dx(BUFF_ADDR(0), instr - 1, ioptr_width, dx_start);
 					delchar_width = dx_instr - dx_prev;
-					if (echo_mode)  //kt mod
+					if (echo_mode)
 					{
 						term_error_line = __LINE__;
 						status = move_cursor_left(dx, delchar_width);
@@ -1046,12 +1046,12 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 				{
 					STORE_OFF(' ', outlen);
 					outlen--;
-					if (echo_mode)  //kt mod
+					if (echo_mode)
 					{
 						IOTT_COMBINED_CHAR_CHECK;
 					}
 					MOVE_BUFF(instr, BUFF_ADDR(instr + 1), outlen - instr);
-					if (echo_mode)  //kt mod
+					if (echo_mode)
 					{	/* First write spaces on all the display columns that the current string occupied.
 						 * Then overwrite that with the new string. This way we are guaranteed all
 						 * display columns are clean.
@@ -1133,7 +1133,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 				dx = (unsigned)(dx_instr + dx_start) % ioptr_width;
 				outlen = instr;
 				escape_edit = TRUE;
-			} else if (echo_mode)  //kt mod
+			} else if (echo_mode)
 			{
 				// When the cursor is at the beginning of the line, we can move it 1 position to the right or to the end of the line.
 				// I have grouped these possibilities in pair. This is more understandable and logical. Sergey Kamenev.
@@ -1152,7 +1152,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 						dx = (dx + inchar_width) % ioptr_width;
 						dx_instr += inchar_width;
 					} else if (0 == end) /* End - end of line */
-						IOTT_MOVE_END_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, dx_outlen, ioptr_width, term_error_line, instr, outlen);  //kt
+						IOTT_MOVE_END_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, dx_outlen, ioptr_width, term_error_line, instr, outlen);
 				}
 				// When the cursor is at the end of the line, we can move it 1 position to the left or to the beginning of the line.
 				if (0 != instr)
@@ -1170,14 +1170,14 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 						dx = (dx - inchar_width + ioptr_width) % ioptr_width;
 						dx_instr -= inchar_width;
 					} else if (0 == home) /* Home - start of line */
-					    IOTT_MOVE_START_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, ioptr_width, term_error_line, instr);  //kt
+					    IOTT_MOVE_START_OF_LINE(tt_ptr->fildes, echo_mode, dx, dx_instr, dx_start, ioptr_width, term_error_line, instr);
 				}
 			}
 			if (0 == insert_key)
 				insert_mode = !insert_mode;	/* toggle */
 			if (0 == right || 0 == left || 0 == insert_key)
 				escape_edit = TRUE;
-			if (escape_edit || (temp_io_state.escape_processing == FALSE))   //kt mod
+			if (escape_edit || (temp_io_state.escape_processing == FALSE))
 			{	/* reset dollar zb if editing function or not trm_escape */
 				memset(io_ptr->dollar.zb, '\0', SIZEOF(io_ptr->dollar.zb));
 				io_ptr->esc_state = START;
@@ -1207,7 +1207,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 		if (0 == outlen && ((io_ptr->dollar.zb + 1) == zb_ptr)) /* No input and no delimiter seen */
 			ret = FALSE;
 	}
-	if (temp_io_state.readsync)  //kt mod
+	if (temp_io_state.readsync)
 	{
 		DOWRITERC(tt_ptr->fildes, &dc3, 1, status);
 		if (0 != status)
@@ -1242,7 +1242,7 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 	v->str.addr = (char *)buffer_start;
 	if (edit_mode)	/* store in recall buffer */
 		iott_recall_array_add(tt_ptr, outlen, dx_outlen, BUFF_CHAR_SIZE * outlen, BUFF_ADDR(0));
-	if (echo_mode)  //kt mod
+	if (echo_mode)
 	{
 		if ((io_ptr->dollar.x += dx_outlen) >= ioptr_width && io_ptr->wrap)
 		{
@@ -1256,14 +1256,14 @@ int	iott_readfl(mval *v, int4 length, uint8 nsec_timeout)	/* timeout in millisec
 	}
 	REVERT_GTMIO_CH(&io_curr_device, ch_set);
 
-	iott_restoreterm(io_ptr); //kt added.  Restore ydb's current IO state, in case this function modified the TTY IO subsystem.
+	iott_restoreterm(io_ptr); //Restore ydb's current IO state, in case this function modified the TTY IO subsystem.
 
 	return ((short)ret);
 
 term_error:
 	save_errno = errno;
 	io_ptr->dollar.za = ZA_IO_ERR;
-	temp_io_state.discard_lf = FALSE;  //kt mod  Added 'temp_io_state.
+	temp_io_state.discard_lf = FALSE;
 	SEND_KEYPAD_LOCAL;	/* to turn keypad off if possible */
 	if (!nsec_timeout)
 		iott_rterm(io_ptr);

--- a/sr_unix/iott_resetterm.c
+++ b/sr_unix/iott_resetterm.c
@@ -40,7 +40,6 @@ error_def(ERR_TCSETATTR);
 
 void  iott_resetterm(io_desc* io_ptr)
 /* ----------------------------------------------------------------------------------------------------------------------
-//kt ADDED NOTES
 PURPOSE: Initially restterm() was called at end of READ commands, which caused problems.  Text here will describe some of those
 	 problems and modifications applied to improve performance.
 
@@ -132,7 +131,6 @@ PURPOSE: Initially restterm() was called at end of READ commands, which caused p
 }
 
 void handle_reset_tty_err(io_desc* io_ptr, int save_errno, int filedes)
-//kt added
 {
 	assert(ENOTTY != save_errno);
 	// Skip TCSETATTR error for ENOTTY (in case fildes is no longer a terminal)
@@ -150,7 +148,6 @@ void handle_reset_tty_err(io_desc* io_ptr, int save_errno, int filedes)
 }
 
 void  iott_restoreterm(io_desc * io_ptr)
-//kt added function
 //Purpose: This will send currently compiled IO state to the TTY IO subsystem.
 //	   This is different from resetterm(), which will return IO state to same as when ydb first started.
 {

--- a/sr_unix/iott_resetterm.c
+++ b/sr_unix/iott_resetterm.c
@@ -38,38 +38,127 @@ GBLREF	boolean_t	exit_handler_active;
 
 error_def(ERR_TCSETATTR);
 
-void  iott_resetterm(io_desc *iod)
+void  iott_resetterm(io_desc* io_ptr)
+/* ----------------------------------------------------------------------------------------------------------------------
+//kt ADDED NOTES
+PURPOSE: Initially restterm() was called at end of READ commands, which caused problems.  Text here will describe some of those
+	 problems and modifications applied to improve performance.
+
+	With original functionality, resetterm() was called after each IO read call, often via macro RESETTERM_IF_NEEDED.
+	This could happen multiple times in a single line of code. For example:
+
+	      USE $P:NOECHO READ *X hang 1 READ Y#1 hang 1 READ Z
+
+	  After each of these READ's, before proceeding to the next command, a resetterm would  be called.
+	  The ideas seemed to be that each command may need to set the IO state in some special way, so when done,
+	  code would reset the TTY IO system.
+
+	  A problem resulting from this system, however, was that this caused an unexpected state **inbetween** IO reads.
+	  One would expect that the IO state would be NOECHO during the 1 second of HANG in the example above.
+	  But if terminal is reset to initial entry IO state after each READ, then the system would actually be back in
+	  ECHO mode during the hang. And if the user typed characters during this 1 second, then they would be shown in
+	  terminal output -- put there by the TTY IO subsystem.
+
+	  The codebase has now been modified such that instead of calling resetterm() after READ commands, ydb
+	  will call a new function called iott_restoreterm(), which will just restore the current ydb compiled IO state.
+	  In the example above, it would restore the NOECHO state, not reset to initial state with accompanying ECHO mode.
+
+	Notice that ydb needs to keep track of three (3) different states.
+	  1) The original state from when ydb was first started.  This is needed so that the terminal TTY settings can
+	     be reset upon exiting ydb.
+	     This will be stored in tt_ptr->initial_io_state.
+	  2) The state that has been set by mumps code, e.g. USE $P:NOECHO.  This can be code in a routine or in direct mode.
+	     This will be stored in tt_ptr->io_state.
+	  3) A state needed for interacting with user in direct mode.  For example, if user in direct mode issues a
+	     USE $P:NOECHO at the command prompt, then while this specified state must be stored, but we DO stil want
+	     the user to be able to type additional commands and see the output via ECHO being on.
+	     This will be stored in tt_ptr->direct_mode_io_state.
+
+	The TTY IO subsystem is controlled by sending a ttio_struct with bitflags specifying the various settings.
+	  Ydb will maintain a copy of this struct in the various tt_ptr->[io_state].ttio_struct's.
+
+	Ydb also has settings on how it manages input, which needs to cooperate with the TTY IO settings.  Previously,
+	  these ydb settings were stored in tt_ptr->term_ctrl, using a different set of bitflags.  Because multiple sets
+	  had to be maintained for each [io_state], and to clarify meaning, these settings have now been moved into
+	  discrete boolean variables in tt_ptr->[io_state].  For example, tt_ptr->io_state.devparam_echo.  This has
+	  removed the need for TRM_NOECHO etc flags from the codebase.
+
+	One might wonder, if the terminal is reset after every IO command, how will the next IO command be completed
+	  in the proper IO state?  The answer is that at the BEGINNING of each IO command, setterm() is called,
+	  often via macro SETTERM_IF_NEEDED.  This ensured that ydb's current working IO state (based on USE commands
+	  etc) is applied to the TTY IO system before completing the upcoming IO command.
+
+	Using new iott_restoreterm() function instead of resetterm() AFTER commands fixed issues with unexpected state between
+	   IO calls, as shown above. But there still is a role for resetterm, esp when leaving ydb.
+
+	When analyzing the codebase to correct above issues, it was initially difficult to determine the purpose of resetterm().
+	  Obviously resetterm() was supposed to reset the terminal.  But _when_ should the terminal be reset, and
+	  _to_what_state_ should the terminal be returned to?  The IO state when ydb first started (i.e. initial_io_state)?  Or
+	  the IO state after $P has been initialized with USE parameters?  Or from the last USE command (i.e. io_state)?
+	  After study, it appeared that resetterm() should return the terminal to the IO state when ydb first started,
+	  i.e. to initial_io_state.
+
+	resetterm() does not, and should not change the state of ydb's IO status (io_state).  If the user or mumps code
+	    has specified NOECHO as a USE parameter, this state should be maintained, regardless of resets to the terminal
+	    that might be applied between IO commands.  THEREFORE, this function just ensures that the TTY IO subsystem
+	    matches tt_ptr->initial_io.ttio_struct.  It doesn't modify, for example, tt_ptr->io_state.canonical.
+
+	At the end of this resetterm function, tt_ptr->setterm_done_by is set to 0.  This is a signal that ydb needs
+	  to set the terminal based on internal state variables the next time it is needed.  This is checked in setterm().
+
+	Notice that after this resetterm(), the TTY IO system and ydb's internal state will be that stored in initial_io_state,
+	But with next READ command, io_state will be restored via setterm.
+
+//----------------------------------------------------------------------------------------------------------------------
+*/
 {
 	int		status;
 	int		save_errno;
-	struct termios 	t;
-	d_tt_struct	*ttptr;
+	d_tt_struct	*tt_ptr;
 
-	ttptr = (d_tt_struct *) iod->dev_sp;
-	if (process_id != ttptr->setterm_done_by)
-		return;	/* "iott_resetterm" already done */
-	if (ttptr->ttio_struct)
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+	if (process_id != tt_ptr->setterm_done_by)
 	{
-	        t = *ttptr->ttio_struct;
-		Tcsetattr(ttptr->fildes, TCSANOW, &t, status, save_errno, CHANGE_TERM_FALSE);
-		if (0 != status)
-		{
-			assert(-1 == status);
-			assert(ENOTTY != save_errno);
-			/* Skip TCSETATTR error for ENOTTY (in case fildes is no longer a terminal) */
-			if ((ENOTTY != save_errno) && (0 == gtm_isanlp(ttptr->fildes)))
-			{
-				ISSUE_NOPRINCIO_BEFORE_RTS_ERROR_IF_APPROPRIATE(iod);	/* just like is done in "iott_use.c" */
-				/* If we are already in the exit handler, do not issue an error for this event as this
-				 * could cause a condition handler overrun (i.e. invoke "ch_overrun()") which would create
-				 * a core file. Since this error most likely means the terminal has gone away, it is better
-				 * to terminate the process without resetting a non-existent terminal than creating a core file.
-				 */
-				if (!exit_handler_active)
-					RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, ttptr->fildes, save_errno);
-			}
-		}
-		ttptr->setterm_done_by = 0;
+		return;	/* "resetterm" already done */
 	}
+
+	//set TTY IO subsystem to value stored in initial_io_state
+	iott_set_tty(io_ptr, &(tt_ptr->initial_io_state.ttio_struct),  handle_reset_tty_err);
+	iott_set_ydb_echo(io_ptr, &(tt_ptr->initial_io_state), &(tt_ptr->io_state));
+
+	tt_ptr->setterm_done_by = 0;	//<-- This will trigger terminal to be set up again next time used, via setterm()
+
 	return;
+}
+
+void handle_reset_tty_err(io_desc* io_ptr, int save_errno, int filedes)
+//kt added
+{
+	assert(ENOTTY != save_errno);
+	// Skip TCSETATTR error for ENOTTY (in case fildes is no longer a terminal)
+	if ((ENOTTY != save_errno) && (0 == gtm_isanlp(filedes)))
+	{
+		ISSUE_NOPRINCIO_BEFORE_RTS_ERROR_IF_APPROPRIATE(io_ptr);	// just like is done in "iott_use.c"
+		// If we are already in the exit handler, do not issue an error for this event as this
+		// could cause a condition handler overrun (i.e. invoke "ch_overrun()") which would create
+		// a core file. Since this error most likely means the terminal has gone away, it is better
+		// to terminate the process without resetting a non-existent terminal than creating a core file.
+		//
+		if (!exit_handler_active)
+			RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, filedes, save_errno);
+	}
+}
+
+void  iott_restoreterm(io_desc * io_ptr)
+//kt added function
+//Purpose: This will send currently compiled IO state to the TTY IO subsystem.
+//	   This is different from resetterm(), which will return IO state to same as when ydb first started.
+{
+	d_tt_struct *   		tt_ptr;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+
+	//Send ydb current active state to underlying TTY IO subsystem
+	iott_set_tty_and_ydb_echo(io_ptr, &(tt_ptr->io_state.ttio_struct), handle_set_tty_err_mode_1);
+
+	tt_ptr->setterm_done_by = process_id;  //signal that another TTY IO set is not currently needed.
 }

--- a/sr_unix/iott_setterm.c
+++ b/sr_unix/iott_setterm.c
@@ -30,7 +30,7 @@
 #include "gtm_isanlp.h"
 
 GBLREF	uint4		process_id;
-GBLREF	boolean_t	exit_handler_active;  			//kt added
+GBLREF	boolean_t	exit_handler_active;
 
 error_def(ERR_TCSETATTR);
 
@@ -60,20 +60,18 @@ void iott_setterm(io_desc *io_ptr)
 // iott_mterm sets the inter-character timer (t.c_cc[VTIME]) to 0.0 seconds so that a read with a zero timeout (ie.  Read x:0) will not wait.
 void iott_mterm(io_desc * io_ptr)
 {
-	cc_t 		vtime;  //kt added
+	cc_t 		vtime;
 	d_tt_struct	*tt_ptr;
 
 	tt_ptr = (d_tt_struct *) io_ptr->dev_sp;
 
-	//kt begin addition
 #ifdef __MVS__
 		vtime = 1;
 #else
 		vtime = 0;
 #endif
-	//kt end addition
 
-	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, vtime, 0, handle_set_tty_err_mode_2);  //kt moved block of code into function
+	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, vtime, 0, handle_set_tty_err_mode_2);
 
 	return;
 }
@@ -85,15 +83,13 @@ void iott_rterm(io_desc *io_ptr)
 	d_tt_struct  	*tt_ptr;
 	tt_ptr = (d_tt_struct *) io_ptr->dev_sp;
 
-	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_2);  //kt moved block of code into function
+	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_2);
 
 	return;
 }
 
 
-//kt begin additions ---------------
 void iott_setterm_for_no_canonical(io_desc * io_ptr,  ttio_state * temp_io_state_ptr)
-//kt added function.
 //Setup terminal with CANONICAL mode OFF.
 //  Needed for reading just one character, e.g. via READ *X command
 //  Also needed for reading fixed length, e.g. READ #1
@@ -108,7 +104,7 @@ void iott_setterm_for_no_canonical(io_desc * io_ptr,  ttio_state * temp_io_state
 	*temp_io_state_ptr = tt_ptr->io_state;  //start with current io_state
 	temp_io_state_ptr->canonical = FALSE;   //if canonical were left on, then TTY IO subsystem wouldn't return character until after NL (or CR) or EOL
 
-	//kt below does same as iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_1), but uses temp_io_state
+	//Below does same as iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_1), but uses temp_io_state
 	iott_compile_ttio_struct(io_ptr, temp_io_state_ptr, 8, 1);
 	iott_set_tty(io_ptr, &(temp_io_state_ptr->ttio_struct), handle_set_tty_err_mode_1);
 	iott_set_ydb_echo(io_ptr, temp_io_state_ptr, temp_io_state_ptr);
@@ -120,7 +116,7 @@ void iott_setterm_for_no_canonical(io_desc * io_ptr,  ttio_state * temp_io_state
 
 
 ttio_state* iott_setterm_for_direct_mode(io_desc* io_ptr)
-//kt added function.  Setup terminal for interaction with user at console in direct mode.
+//Setup terminal for interaction with user at console in direct mode.
 //NOTE: This function is different from iott_setterm_for_no_canonical().  That populates a structure passed in.
 //         Whereas this function returns a pointer to an existing structure.
 {
@@ -130,7 +126,7 @@ ttio_state* iott_setterm_for_direct_mode(io_desc* io_ptr)
 	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
 	direct_mode_io_state_ptr = &(tt_ptr->direct_mode_io_state);
 
-	//kt below does same as iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_1), but uses direct_mode_io_state
+	//Below does same as iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_1), but uses direct_mode_io_state
 	iott_compile_ttio_struct(io_ptr, direct_mode_io_state_ptr, 8, 1);
 	iott_set_tty(io_ptr, &(direct_mode_io_state_ptr->ttio_struct), handle_set_tty_err_mode_1);
 	iott_set_ydb_echo(io_ptr, direct_mode_io_state_ptr, direct_mode_io_state_ptr);
@@ -141,7 +137,7 @@ ttio_state* iott_setterm_for_direct_mode(io_desc* io_ptr)
 }
 
 void handle_set_tty_err_mode_1(io_desc* io_ptr, int save_errno, int filedes)  //for SET_TTY_CHECK_ERRORS_MODE_1
-//kt added
+
 {
 	if (gtm_isanlp(filedes) == 0)
 		RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, filedes, save_errno);
@@ -149,14 +145,13 @@ void handle_set_tty_err_mode_1(io_desc* io_ptr, int save_errno, int filedes)  //
 
 
 void handle_set_tty_err_mode_2(io_desc* io_ptr, int save_errno, int filedes)  //for SET_TTY_CHECK_ERRORS_MODE_2
-//kt added
+
 {
 	rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, filedes, save_errno);
 }
 
 
 void iott_compile_ttio_struct(io_desc * io_ptr, ttio_state* an_io_state_ptr, cc_t vtime, cc_t vmin)
-//kt added function
 //Purpose: to compile any state variables into ttio_struct, ready to be later passed to TTY IO system
 //         NOTE: Because tt_ptr->io_state.term_ctrl settings have to match TTY IO system, it should also
 //		 be set up -- but will not be handling here.  See iott_set_ydb_echo()
@@ -328,7 +323,8 @@ PARAM CANONICAL --> TTY CANONICAL  <-- direct sync between these two.
 
 The reason that io_state.ydb_echo is NOT set here is because there is a case where initial_io_state needs
   to be source instead of io_state. So this will be set in a separate function, iott_set_ydb_echo()
-  //kt update: after changing this function to accept arbitrary an_io_state_ptr, perhaps all could be done in this one function.  Would need to be researched.
+  //Update: after changing this function to accept arbitrary an_io_state_ptr, perhaps all could be done in this one function.
+  //        ... Would need to be researched.
 
 */
 {
@@ -382,7 +378,6 @@ The reason that io_state.ydb_echo is NOT set here is because there is a case whe
 }
 
 void iott_set_ydb_echo(io_desc* io_ptr, ttio_state* source_io_state_ptr, ttio_state* output_io_state_ptr)
-//kt added
 //Purpose: Setup output_io_state_ptr->ydb_echo settings have to match passed *source_io_state_ptr
 //
 //The reason that io_state.ydb_echo is set separately here is because there is a case where initial_io_state needs
@@ -413,7 +408,6 @@ void iott_set_ydb_echo(io_desc* io_ptr, ttio_state* source_io_state_ptr, ttio_st
 
 
 tty_getsetattr_status iott_compile_state_and_set_tty_and_ydb_echo(io_desc * io_ptr, cc_t vtime, cc_t vmin, set_tty_err_handler an_err_handler)
-//kt added function
 //PURPOSE: To create common function for compiling ydb IO state and then setting tty io system.
 //Input:  io_ptr -- 		pointer to relevant IO structure.  NOTE: other places in codebase used "iod" for this pointer
 //        vtime  -- 		timeout in deciseconds if noncanonical read (VTIME).  E.g. '8' --> 0.8 sec timeout.
@@ -431,7 +425,6 @@ tty_getsetattr_status iott_compile_state_and_set_tty_and_ydb_echo(io_desc * io_p
 }
 
 tty_getsetattr_status iott_set_tty_and_ydb_echo(io_desc* io_ptr, struct termios* ttio_struct_ptr, set_tty_err_handler an_err_handler)
-//kt added
 {
 	tty_getsetattr_status		status;
 	d_tt_struct *   		tt_ptr;
@@ -444,7 +437,6 @@ tty_getsetattr_status iott_set_tty_and_ydb_echo(io_desc* io_ptr, struct termios*
 }
 
 tty_getsetattr_status iott_set_tty(io_desc * io_ptr, struct termios * ttio_struct_ptr, set_tty_err_handler an_err_handler)
-//kt added function
 //PURPOSE: To create common function for actually setting tty io system.
 //Input:  io_ptr -- 		pointer to relevant IO structure.
 //        ttio_struct_ptr --	pointer to ttio_struct data structure to send to TTY IO subsystem

--- a/sr_unix/iott_setterm.c
+++ b/sr_unix/iott_setterm.c
@@ -30,38 +30,23 @@
 #include "gtm_isanlp.h"
 
 GBLREF	uint4		process_id;
+GBLREF	boolean_t	exit_handler_active;  			//kt added
 
 error_def(ERR_TCSETATTR);
 
-void iott_setterm(io_desc *ioptr)
+void iott_setterm(io_desc *io_ptr)
 {
-	int		status;
-	int		save_errno;
-	struct termios	t;
 	d_tt_struct	*tt_ptr;
 
-	tt_ptr = (d_tt_struct *)ioptr->dev_sp;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
 	if (0 != tt_ptr->setterm_done_by)
 	{
 		assert(process_id == tt_ptr->setterm_done_by);
-		return;	/* "iott_setterm" already done */
+		return;	/* "setterm" already done */
 	}
-	t = *tt_ptr->ttio_struct;
-	if (tt_ptr->canonical)
-	{	t.c_lflag &= ~(ECHO);
-		t.c_lflag |= ICANON;
-	}else
-	{	t.c_lflag &= ~(ICANON | ECHO);
-		t.c_cc[VTIME] = 8;
-		t.c_cc[VMIN] = 1;
-	}
-	t.c_iflag &= ~(ICRNL);
-	Tcsetattr(tt_ptr->fildes, TCSANOW, &t, status, save_errno, CHANGE_TERM_TRUE);
-	if (0 != status)
-	{
-		if (gtm_isanlp(tt_ptr->fildes) == 0)
-			RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, tt_ptr->fildes, save_errno);
-	}
+
+	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_1);
+
 	tt_ptr->setterm_done_by = process_id;
 	return;
 }
@@ -72,62 +57,415 @@ void iott_setterm(io_desc *ioptr)
    terminal to be unreachable thereafter.
 */
 
-/* iott_mterm sets the inter-character timer (t.c_cc[VTIME]) to 0.0 seconds
-   so that a read with a zero timeout (ie.  Read x:0) will not wait.
-*/
-
-void iott_mterm(io_desc *ioptr)
+// iott_mterm sets the inter-character timer (t.c_cc[VTIME]) to 0.0 seconds so that a read with a zero timeout (ie.  Read x:0) will not wait.
+void iott_mterm(io_desc * io_ptr)
 {
-	int		status;
-	int		save_errno;
-	struct termios	t;
+	cc_t 		vtime;  //kt added
 	d_tt_struct	*tt_ptr;
 
-	tt_ptr = (d_tt_struct *) ioptr->dev_sp;
-	t = *tt_ptr->ttio_struct;
-	if (tt_ptr->canonical)
-	{	t.c_lflag &= ~(ECHO);
-		t.c_lflag |= ICANON;
-	}else
-	{	t.c_lflag &= ~(ICANON | ECHO);
+	tt_ptr = (d_tt_struct *) io_ptr->dev_sp;
+
+	//kt begin addition
 #ifdef __MVS__
-		t.c_cc[VTIME] = 1;
+		vtime = 1;
 #else
-		t.c_cc[VTIME] = 0;
+		vtime = 0;
 #endif
-		t.c_cc[VMIN] = 0;
-	}
-	t.c_iflag &= ~(ICRNL);
-	Tcsetattr(tt_ptr->fildes, TCSANOW, &t, status, save_errno, CHANGE_TERM_TRUE);
-	if (0 != status)
-		rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, tt_ptr->fildes, save_errno);
+	//kt end addition
+
+	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, vtime, 0, handle_set_tty_err_mode_2);  //kt moved block of code into function
+
 	return;
 }
 
 
-/* iott_rterm restores the inter-character timer (t.c_cc[VTIME]) to 0.8 seconds
-*/
-
-void iott_rterm(io_desc *ioptr)
+// iott_rterm restores the inter-character timer (t.c_cc[VTIME]) to 0.8 seconds
+void iott_rterm(io_desc *io_ptr)
 {
-	int		status;
-	int		save_errno;
-	struct termios	t;
 	d_tt_struct  	*tt_ptr;
+	tt_ptr = (d_tt_struct *) io_ptr->dev_sp;
 
-	tt_ptr = (d_tt_struct *) ioptr->dev_sp;
-	t = *tt_ptr->ttio_struct;
-	if (tt_ptr->canonical)
-	{	t.c_lflag &= ~(ECHO);
-		t.c_lflag |= ICANON;
-	}else
-	{	t.c_lflag &= ~(ICANON | ECHO);
-		t.c_cc[VTIME] = 8;
-		t.c_cc[VMIN] = 1;
-	}
-	t.c_iflag &= ~(ICRNL);
-	Tcsetattr(tt_ptr->fildes, TCSANOW, &t, status, save_errno, CHANGE_TERM_TRUE);
-	if (0 != status)
-		rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, tt_ptr->fildes, save_errno);
+	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_2);  //kt moved block of code into function
+
 	return;
+}
+
+
+//kt begin additions ---------------
+void iott_setterm_for_no_canonical(io_desc * io_ptr,  ttio_state * temp_io_state_ptr)
+//kt added function.
+//Setup terminal with CANONICAL mode OFF.
+//  Needed for reading just one character, e.g. via READ *X command
+//  Also needed for reading fixed length, e.g. READ #1
+//NOTE: This function is different from iott_setterm_for_direct_mode().  That returns a pointer to an existing structure.
+//       But this populates a structure passed in.
+{
+	d_tt_struct*			tt_ptr;
+	ttio_state*			io_state_ptr;
+
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+
+	*temp_io_state_ptr = tt_ptr->io_state;  //start with current io_state
+	temp_io_state_ptr->canonical = FALSE;   //if canonical were left on, then TTY IO subsystem wouldn't return character until after NL (or CR) or EOL
+
+	//kt below does same as iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_1), but uses temp_io_state
+	iott_compile_ttio_struct(io_ptr, temp_io_state_ptr, 8, 1);
+	iott_set_tty(io_ptr, &(temp_io_state_ptr->ttio_struct), handle_set_tty_err_mode_1);
+	iott_set_ydb_echo(io_ptr, temp_io_state_ptr, temp_io_state_ptr);
+
+	tt_ptr->setterm_done_by = 0;  //signal that terminal will need to be setup again before next use.
+
+	return;
+}
+
+
+ttio_state* iott_setterm_for_direct_mode(io_desc* io_ptr)
+//kt added function.  Setup terminal for interaction with user at console in direct mode.
+//NOTE: This function is different from iott_setterm_for_no_canonical().  That populates a structure passed in.
+//         Whereas this function returns a pointer to an existing structure.
+{
+	d_tt_struct*			tt_ptr;
+	ttio_state* 			direct_mode_io_state_ptr;
+
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+	direct_mode_io_state_ptr = &(tt_ptr->direct_mode_io_state);
+
+	//kt below does same as iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_1), but uses direct_mode_io_state
+	iott_compile_ttio_struct(io_ptr, direct_mode_io_state_ptr, 8, 1);
+	iott_set_tty(io_ptr, &(direct_mode_io_state_ptr->ttio_struct), handle_set_tty_err_mode_1);
+	iott_set_ydb_echo(io_ptr, direct_mode_io_state_ptr, direct_mode_io_state_ptr);
+
+	tt_ptr->setterm_done_by = 0;  //signal that terminal will need to be setup again before next use.
+
+	return direct_mode_io_state_ptr;
+}
+
+void handle_set_tty_err_mode_1(io_desc* io_ptr, int save_errno, int filedes)  //for SET_TTY_CHECK_ERRORS_MODE_1
+//kt added
+{
+	if (gtm_isanlp(filedes) == 0)
+		RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, filedes, save_errno);
+}
+
+
+void handle_set_tty_err_mode_2(io_desc* io_ptr, int save_errno, int filedes)  //for SET_TTY_CHECK_ERRORS_MODE_2
+//kt added
+{
+	rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, filedes, save_errno);
+}
+
+
+void iott_compile_ttio_struct(io_desc * io_ptr, ttio_state* an_io_state_ptr, cc_t vtime, cc_t vmin)
+//kt added function
+//Purpose: to compile any state variables into ttio_struct, ready to be later passed to TTY IO system
+//         NOTE: Because tt_ptr->io_state.term_ctrl settings have to match TTY IO system, it should also
+//		 be set up -- but will not be handling here.  See iott_set_ydb_echo()
+/*
+Input: an_io_state_ptr -- pointer to IO state structure
+       vtime  -- sets VTIME parameter (timeout time) if canonical mode
+       vmin   -- sets VMIN parameter (minimum chars to read) if canonical mode
+
+    From: https://www.man7.org/linux/man-pages/man3/termios.3.html
+    VTIME  Timeout in deciseconds for noncanonical read (TIME).
+    VMIN   Minimum number of characters for noncanonical read (MIN). <-- note MIN is not minutes.
+    ...
+     In noncanonical mode input is available immediately (without the
+       user having to type a line-delimiter character), no input
+       processing is performed, and line editing is disabled.  The read
+       buffer will only accept 4095 chars; this provides the necessary
+       space for a newline char if the input mode is switched to
+       canonical.  The settings of MIN (c_cc[VMIN]) and TIME
+       (c_cc[VTIME]) determine the circumstances in which a read(2)
+       completes; there are four distinct cases:
+
+       MIN == 0, TIME == 0 (polling read)
+              If data is available, read(2) returns immediately, with
+              the lesser of the number of bytes available, or the number
+              of bytes requested.  If no data is available, read(2)
+              returns 0.
+
+       MIN > 0, TIME == 0 (blocking read)
+              read(2) blocks until MIN bytes are available, and returns
+              up to the number of bytes requested.
+
+       MIN == 0, TIME > 0 (read with timeout)
+              TIME specifies the limit for a timer in tenths of a
+              second.  The timer is started when read(2) is called.
+              read(2) returns either when at least one byte of data is
+              available, or when the timer expires.  If the timer
+              expires without any input becoming available, read(2)
+              returns 0.  If data is already available at the time of
+              the call to read(2), the call behaves as though the data
+              was received immediately after the call.
+
+       MIN > 0, TIME > 0 (read with interbyte timeout)
+              TIME specifies the limit for a timer in tenths of a
+              second.  Once an initial byte of input becomes available,
+              the timer is restarted after each further byte is
+              received.  read(2) returns when any of the following
+              conditions is met:
+
+              •  MIN bytes have been received.
+              •  The interbyte timer expires.
+              •  The number of bytes requested by read(2) has been
+                 received.  (POSIX does not specify this termination
+                 condition, and on some other implementations read(2)
+                 does not return in this case.)
+
+              Because the timer is started only after the initial byte
+              becomes available, at least one byte will be read.  If
+              data is already available at the time of the call to
+              read(2), the call behaves as though the data was received
+              immediately after the call.
+
+----------------------------------------------------------------------------------------------------------------------------------------
+  //NOTE: Below is definition of flags. Not all are set here, and will just inherit values from initial state, before device was opened.
+
+  tcflag_t c_iflag;	// input mode flags
+  			//	    (Octal) :         Binary
+                        // IGNBRK  (0000001): 000000000000000000000001 Ignore break condition.
+                        // BRKINT  (0000002): 000000000000000000000010 Signal interrupt on break.
+                        // IGNPAR  (0000004): 000000000000000000000100 Ignore characters with parity errors.
+                        // PARMRK  (0000010): 000000000000000000001000 Mark parity and framing errors.
+                        // INPCK   (0000020): 000000000000000000010000 Enable input parity check.
+                        // ISTRIP  (0000040): 000000000000000000100000 Strip 8th bit off characters.
+                        // INLCR   (0000100): 000000000000000001000000 Map NL to CR on input.
+                        // IGNCR   (0000200): 000000000000000010000000 Ignore CR.
+                        // ICRNL   (0000400): 000000000000000100000000 Map CR to NL on input.
+                        // IUCLC   (0001000): 000000000000001000000000 Map uppercase characters to lower case on input  (not in POSIX).
+                        // IXON    (0002000): 000000000000010000000000 Enable start/stop output control.
+                        // IXANY   (0004000): 000000000000100000000000 Enable any character to restart  output.
+                        // IXOFF   (0010000): 000000000001000000000000 Enable start/stop input  control.
+                        // IMAXBEL (0020000): 000000000010000000000000 Ring bell wh en input queue is full (not in POSIX).
+                        // IUTF8   (0040000): 000000000100000000000000 Input is UTF8 (not in POSIX).
+The above constants are define in /usr/include/x86_64-linux-gnu/bits/termios-c_iflag.h
+
+  tcflag_t c_oflag;	// output mode flags   //NOTE: doesn't seem to be used in yottadb
+  tcflag_t c_cflag;	// control mode flags  //NOTE: doesn't seem to be used in yottadb
+
+  tcflag_t c_lflag;	// local mode flags
+  			//	 (Octal):    Binary
+                        // ISIG   (0001): 000000000001 Enable signals.
+                        // ICANON (0002): 000000000010 Canonical input (erase and kill processing).
+                        // XCASE  (0004): 000000000100 (obsolete), Flip upper and lower case (not in POSIX)
+                        // ECHO   (0010): 000000001000 Enable echo.
+                        // ECHOE  (0020): 000000010000 Echo erase character as error-correcting backspace
+                        // ECHOK  (0040): 000000100000 Echo KILL.
+                        // ECHONL (0100): 000001000000 Echo NL.
+                        // NOFLSH (0200): 000010000000 Disable flush after interrupt or quit.
+                        // TOSTOP (0400): 000100000000 Send SIGTTOU for background output.
+The above constants are define in /usr/include/x86_64-linux-gnu/bits/termios-c_lflag.h
+
+NOTE:  For TTY IO signals, e.g. ISIG (enable signals), that are never modified by YDB, the state will not
+       be stored in separate tt_ptr->io_state variables.  Instead the combined state will be contained in
+       tty_ptr->io_state.ttio_struct and tty_ptr->initial_io_state.ttio_struct
+
+NOTE!! --> One of the most confusing elements of IO state is echo status!
+	This stems, in part, because for things to work properly BOTH the TTY IO subsystem AND ydb's settings
+  	have to be configured correctly to work together.
+
+Here are the various parts to consider:
+  -- ECHO mode as a device parameter.  E.g.  USE $P:NOECHO    Stored in io_state.devparam_echo
+  -- The bit flag in the ttio_struct c_lflag specifying TTY IO echo status.  E.g. 00000001000
+  -- ydb settings for echo.  Previously stored in .term_ctrl, but now stored in io_state.ydb_echo boolean
+  These are not redundant, and have to be stored separately.
+
+When CANONICAL mode is active, there is an extra layer of complexity because is affects the behavior of echo.
+
+In the table below are all combinations of 4 relevant variables, giving 16 combination.
+  -- "PARAM CANONICAL" is the device parameter [NO]CANONICAL.  e.g. USE $P:CANONICAL
+  -- "PARAM ECHO" is the device parameter [NO]ECHO.  E.g.  USE $P:NOECHO
+  -- "TTY ECHO" means the bit flag that will be sent to the TTY IO subsystem
+  -- "io_state.ydb_echo" means the ydb settings which determine if it provides echo for input.
+
+As user types "hello<return>, what happens in each case?
+
+NOTE: In table below, "H e l l o" is used to show that characters are returned one at a time, not that space is added between.
+
+      PARAM      PARAM                 io_state.
+     CANONICAL   ECHO     TTY ECHO     ydb_echo     USER TYPES         TTY OUTPUTS   YDB OUTPUTS   NET OUTPUT       COMMENT
+ 1     (+)        (+)       (+)         (-)         Hello<enter>         Hello         ""              Hello         OK
+ 2     (+)        (+)       (+)         (+)         Hello<enter>         Hello        Hello         Hello Hello      BAD
+ 3     (+)        (+)       (-)         (-)         Hello<enter>          ""           ""                ""          violates PARAM ECHO (+)
+ 4     (+)        (+)       (-)         (+)         Hello<enter>          ""          Hello            Hello         BAD because output only appears AFTER <enter>
+ 5     (+)        (-)       (+)         (-)         Hello<enter>         Hello        ""               Hello         violates  PARAM ECHO (-)
+ 6     (+)        (-)       (+)         (+)         Hello<enter>         Hello        ""               Hello         violates  PARAM ECHO (-)
+ 7     (+)        (-)       (-)         (-)         Hello<enter>          ""          ""               ""            OK
+ 8     (+)        (-)       (-)         (+)         Hello<enter>          ""          Hello            Hello         violates PARAM ECHO (-)
+ 9     (-)        (+)       (+)         (-)         Hello<enter>        H e l l o      ""              Hello         OK
+10     (-)        (+)       (+)         (+)         Hello<enter>        H e l l o    H e l l o        HHeelloo       BAD
+11     (-)        (+)       (-)         (-)         Hello<enter>           ""          ""              ""            violates PARAM ECHO (+)
+12     (-)        (+)       (-)         (+)         Hello<enter>           ""        H e l l o         Hello         OK
+13     (-)        (-)       (+)         (-)         Hello<enter>        H e l l o      ""              Hello         volates PARAM ECHO (-)
+14     (-)        (-)       (+)         (+)         Hello<enter>        H e l l o    H e l l o        HHeelloo       volates PARAM ECHO (-)
+15     (-)        (-)       (-)         (-)         Hello<enter>           ""          ""               ""           OK
+16     (-)        (-)       (-)         (+)         Hello<enter>           ""        H e l l o         Hello         violates PARAM ECHO (-)
+
+SUMMARY OF ACCEPTABLE CONFIGURATIONS
+
+      PARAM      PARAM                io_state.
+     CANONICAL   ECHO     TTY ECHO     ydb_echo     USER TYPES         TTY OUTPUTS   YDB OUTPUTS   NET OUTPUT       COMMENT
+ 1     (+)        (+)       (+)         (-)         Hello<enter>         Hello         ""              Hello         OK
+ 7     (+)        (-)       (-)         (-)         Hello<enter>          ""           ""                ""          OK
+ 9     (-)        (+)       (+)         (-)         Hello<enter>        H e l l o      ""              Hello         OK
+12     (-)        (+)       (-)         (+)         Hello<enter>          ""         H e l l o         Hello         OK
+15     (-)        (-)       (-)         (-)         Hello<enter>          ""           ""                ""          OK
+
+The above shows that if the user DOES want output [CANONICAL (-) and PARAM ECHO (+)],  (items 9 & 12) then this can be achieve two different ways:
+ 9 -- TTY (+) and io_state.ydb_echo (-)   <--- This lets TTY IO take care of output
+12 -- TTY (-) and io_state.ydb_echo (+)   <--- This lets YDB take care of output  (preferred)
+
+Will exclude #9, and use #12 instead, and we therefore have this logic:
+
+PARAM CANONICAL --> TTY CANONICAL  <-- direct sync between these two.
+
+     PARAM     PARAM
+   CANONICAL   ECHO      -->  TTY ECHO                                 io_state.ydb_echo
+ 1    (+)       (+)      -->    (+)       FYI, to be set elsewhere --> (-)
+ 7    (+)       (-)      -->    (-)       FYI, to be set elsewhere --> (-)
+12    (-)       (+)      -->    (-)       FYI, to be set elsewhere --> (+)
+15    (-)       (-)      -->    (-)       FYI, to be set elsewhere --> (-)
+
+The reason that io_state.ydb_echo is NOT set here is because there is a case where initial_io_state needs
+  to be source instead of io_state. So this will be set in a separate function, iott_set_ydb_echo()
+  //kt update: after changing this function to accept arbitrary an_io_state_ptr, perhaps all could be done in this one function.  Would need to be researched.
+
+*/
+{
+	d_tt_struct * 		tt_ptr;
+	tt_ptr = (d_tt_struct *) io_ptr->dev_sp;
+	struct termios		t;
+
+	//Start with TTY IO state from when first entered ydb.
+	t = tt_ptr->initial_io_state.ttio_struct;
+
+	if (an_io_state_ptr->canonical)
+	{
+		SET_BIT_FLAG_ON(ICANON, t.c_lflag);
+
+		//NOTE: In canonical mode, the TTY system won't end input until newline (NL) found.
+		//	To enable termination on CR (enter key), then must enable CR->NL mapping.
+		SET_BIT_FLAG_ON(ICRNL, t.c_iflag); 	//turn ON ICRNL  = turn ON  Map CR to NL on input.
+		SET_BIT_FLAG_OFF(INLCR, t.c_iflag); 	//turn OFF INLCR = turn OFF Map NL to CR on input.
+
+		//	   PARAM     PARAM
+		//	  CANONICAL   ECHO      -->  TTY ECHO                                  io_state.ydb_echo
+		//     1    (+)       (+)             (+)         FYI, to be set elsewhere --> (-)
+		//     7    (+)       (-)             (-)         FYI, to be set elsewhere --> (-)
+		SET_BIT_FLAG_BY_BOOL(an_io_state_ptr->devparam_echo, ECHO, t.c_lflag);
+		//note: io_state.ydb_echo also needs to be set.  Will be done in iott_set_ydb_echo()
+
+	} else  //NOT canonical
+	{
+		//	   PARAM     PARAM
+		//	  CANONICAL   ECHO      -->  TTY ECHO                                io_state.ydb_echo
+		//    12    (-)       (+)             (-)       FYI, to be set elsewhere --> (+)
+		//    15    (-)       (-)             (-)       FYI, to be set elsewhere --> (-)
+
+		SET_BIT_FLAG_OFF(ICANON, t.c_lflag);	//turn OFF ICANON = turn off TTY canonical mode
+		SET_BIT_FLAG_OFF(ICRNL,  t.c_iflag);	//turn OFF ICRNL  = turn OFF Map CR to NL on input.
+		SET_BIT_FLAG_OFF(INLCR,  t.c_iflag);	//turn OFF INLCR  = turn OFF Map NL to CR on input.
+
+		t.c_cc[VTIME] = vtime;			//this is deciseconds of timeout length
+		t.c_cc[VMIN] = vmin;			//this is minimum number of chars to read (min is NOT 'minutes')
+
+		SET_BIT_FLAG_OFF(ECHO, t.c_lflag);	//turn OFF TTY echo
+		//note: io_state.ydb_echo also needs to be set.  Will be done in iott_set_ydb_echo()
+
+	}
+	SET_BIT_FLAG_BY_BOOL(an_io_state_ptr->hostsync, IXOFF, t.c_iflag);  // start/stop input control
+	SET_BIT_FLAG_BY_BOOL(an_io_state_ptr->ttsync,   IXON,  t.c_iflag);  // start/stop output control
+
+	//Save compiled ttio_struct
+	//Should contain all state elements from tt_ptr->io_state
+	an_io_state_ptr->ttio_struct = t;
+}
+
+void iott_set_ydb_echo(io_desc* io_ptr, ttio_state* source_io_state_ptr, ttio_state* output_io_state_ptr)
+//kt added
+//Purpose: Setup output_io_state_ptr->ydb_echo settings have to match passed *source_io_state_ptr
+//
+//The reason that io_state.ydb_echo is set separately here is because there is a case where initial_io_state needs
+//  to be the source instead of io_state.
+
+//       PARAM     PARAM
+//     CANONICAL   ECHO     -->   io_state.ydb_echo
+// 1     (+)       (+)      -->   (-)
+// 7     (+)       (-)      -->   (-)
+// 12    (-)       (+)      -->   (+)
+// 15    (-)       (-)      -->   (-)
+
+{
+	d_tt_struct *   		tt_ptr;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+
+	if (source_io_state_ptr->canonical)
+	{
+		//configuration #1 & #7 from table above
+		output_io_state_ptr->ydb_echo = FALSE;
+
+	} else  //NOT canonical
+	{
+		//configuration #12 & #15 from table in iott_compile_ttio_struct above
+		output_io_state_ptr->ydb_echo = source_io_state_ptr->devparam_echo;
+	}
+}
+
+
+tty_getsetattr_status iott_compile_state_and_set_tty_and_ydb_echo(io_desc * io_ptr, cc_t vtime, cc_t vmin, set_tty_err_handler an_err_handler)
+//kt added function
+//PURPOSE: To create common function for compiling ydb IO state and then setting tty io system.
+//Input:  io_ptr -- 		pointer to relevant IO structure.  NOTE: other places in codebase used "iod" for this pointer
+//        vtime  -- 		timeout in deciseconds if noncanonical read (VTIME).  E.g. '8' --> 0.8 sec timeout.
+//        vmin   -- 		minimum number of characters if noncanonical read (VMIN)
+//        err_check_mode -- 	determines how error state is handled.
+
+{
+	tty_getsetattr_status	status;
+	d_tt_struct *   	tt_ptr;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+
+	iott_compile_ttio_struct(io_ptr,  &(tt_ptr->io_state), vtime, vmin);   //compiles IO state into io_state.ttio_struct
+	status = iott_set_tty_and_ydb_echo(io_ptr, &(tt_ptr->io_state.ttio_struct), an_err_handler);	//send to underlying TTY IO subsystem
+	return status;
+}
+
+tty_getsetattr_status iott_set_tty_and_ydb_echo(io_desc* io_ptr, struct termios* ttio_struct_ptr, set_tty_err_handler an_err_handler)
+//kt added
+{
+	tty_getsetattr_status		status;
+	d_tt_struct *   		tt_ptr;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+
+	status = iott_set_tty(io_ptr, ttio_struct_ptr, an_err_handler);
+	iott_set_ydb_echo(io_ptr, &(tt_ptr->io_state), &(tt_ptr->io_state));
+
+	return status;
+}
+
+tty_getsetattr_status iott_set_tty(io_desc * io_ptr, struct termios * ttio_struct_ptr, set_tty_err_handler an_err_handler)
+//kt added function
+//PURPOSE: To create common function for actually setting tty io system.
+//Input:  io_ptr -- 		pointer to relevant IO structure.
+//        ttio_struct_ptr --	pointer to ttio_struct data structure to send to TTY IO subsystem
+//        err_check_mode --	determines how error state is handled.
+//NOTE: io_state.ydb_echo needs to match the TTY IO settings, but it is not handled here.  See iott_set_ydb_echo()
+{
+	tty_getsetattr_status		status;
+	int				save_errno;
+	int				filedes;
+	d_tt_struct *   		tt_ptr;
+	DCL_THREADGBL_ACCESS;
+
+	SETUP_THREADGBL_ACCESS;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+	filedes = tt_ptr->fildes;
+
+	Tcsetattr(filedes, TCSANOW, ttio_struct_ptr, status, save_errno, CHANGE_TERM_TRUE); //send ttio_struct_ptr to TTY IO subsystem
+	if ((GETSETATTR_SUCCESS != status) && (an_err_handler != NULL))
+	{
+		an_err_handler(io_ptr, save_errno, filedes);
+
+	}
+	return status;
 }

--- a/sr_unix/iott_use.c
+++ b/sr_unix/iott_use.c
@@ -67,6 +67,8 @@ LITDEF unsigned char filter_index[27] =
 	,4, 4, 4
 };
 
+const io_termmask NULL_TERM_MASK = { {0, 0, 0, 0, 0, 0, 0, 0} };   //kt added
+
 GBLREF boolean_t		ctrlc_on, hup_on, prin_in_dev_failure, prin_out_dev_failure;
 GBLREF char			*CURSOR_ADDRESS, *CLR_EOL, *CLR_EOS;
 GBLREF io_pair			io_curr_device, io_std_device;
@@ -85,32 +87,22 @@ error_def(ERR_TTINVFILTER);
 error_def(ERR_WIDTHTOOSMALL);
 error_def(ERR_ZINTRECURSEIO);
 
-void iott_use(io_desc *iod, mval *pp)
+void iott_use(io_desc * io_ptr, mval * devparms)
 {
-	boolean_t		flush_input, terminator_specified = FALSE;
-	char			dc1, *ttab;
-	d_tt_struct		*temp_ptr, *tt_ptr;
-	int			p_offset, fil_type, save_errno, status;
-	int4			length, width;
-	io_desc			*d_in, *d_out;
-	io_termmask		mask_term;
+	d_tt_struct *		tt_ptr;
+	int			p_offset;
 	struct sigaction	act;
-	struct termios		t;
-	mstr			chset_mstr;
-	gtm_chset_t		temp_chset = -1, old_ichset;
-	uint4			mask_in;
-	unsigned char		ch, len;
 	boolean_t		ch_set;
 	mval			mv;
 	DCL_THREADGBL_ACCESS;
 
 	SETUP_THREADGBL_ACCESS;
 	p_offset = 0;
-	assert(iod->state == dev_open);
-	ESTABLISH_GTMIO_CH(&iod->pair, ch_set);
-	iott_flush(iod);
-	tt_ptr = (d_tt_struct *)iod->dev_sp;
-	if (*(pp->str.addr + p_offset) != iop_eol)
+	assert(io_ptr->state == dev_open);
+	ESTABLISH_GTMIO_CH(&io_ptr->pair, ch_set);
+	iott_flush(io_ptr);
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+	if (*(devparms->str.addr + p_offset) != iop_eol)
 	{
 		if (tt_ptr->mupintr)
 			if (dollar_zininterrupt)
@@ -119,39 +111,163 @@ void iott_use(io_desc *iod, mval *pp)
 			{	/* The interrupted read was not properly resumed so clear it now */
 				tt_ptr->mupintr = FALSE;
 				tt_ptr->tt_state_save.who_saved = ttwhichinvalid;
-				io_find_mvstent(iod, TRUE);
+				io_find_mvstent(io_ptr, TRUE);
 			}
-		status = tcgetattr(tt_ptr->fildes, &t);
-		if (0 != status)
+
+		//setup ydb IO state (but not TTY IO subsystem) based on device parameters
+		iott_use_params_to_state(io_ptr, devparms);
+
+		//kt Moved functionality of prior block of code into iott_compile_state_and_set_tty_and_ydb_echo(),
+		//kt   and calling below outside IF block, so that even if there are no devparams, it will still be called.
+	} else if (tt_ptr->mupintr && !dollar_zininterrupt)
+	{	/* The interrupted read was not properly resumed so clear it now */
+		tt_ptr->mupintr = FALSE;
+		tt_ptr->tt_state_save.who_saved = ttwhichinvalid;
+		io_find_mvstent(io_ptr, TRUE);	/* clear mv stack entry */
+	}
+
+	//kt  Send IO state to TTY IO subsystem.  8 is default time, 1 is minimum chars; can be changed later.
+	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_3);   //kt added, moving funcitonality down from above.
+
+	REVERT_GTMIO_CH(&io_ptr->pair, ch_set);
+	return;
+}
+
+void handle_set_tty_err_mode_3(io_desc* io_ptr, int save_errno, int filedes)  //for SET_TTY_CHECK_ERRORS_MODE_3
+//kt added
+{
+	assert(WBTEST_YDB_KILL_TERMINAL == ydb_white_box_test_case_number);
+	ISSUE_NOPRINCIO_BEFORE_RTS_ERROR_IF_APPROPRIATE(io_ptr);
+	RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, filedes, save_errno);
+}
+
+
+void iott_use_params_to_state(io_desc * io_ptr, mval * devparms)
+//kt added function, using code from iott_use()
+//kt NOTE: This saves the IO state into ydb data structures, based on USE parameters.
+//         AND it also does some actions, if param calls for action.  It does NOT write anything out to the TTY IO subsystem.
+{
+	d_tt_struct * 		tt_ptr;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+	iott_common_params_to_state(io_ptr, &tt_ptr->io_state, devparms, iott_is_valid_use_param);
+}
+
+boolean_t iott_is_valid_use_param(io_params_type aparam)  // is aparam valid for USE command?
+//kt added function
+{
+	boolean_t	result;
+	result = (
+		(aparam == iop_canonical) 	||
+		(aparam == iop_nocanonical) 	||
+		(aparam == iop_empterm) 	||
+		(aparam == iop_noempterm) 	||
+		(aparam == iop_cenable) 	||
+		(aparam == iop_nocenable) 	||
+		(aparam == iop_clearscreen) 	||
+		(aparam == iop_convert) 	||
+		(aparam == iop_noconvert) 	||
+		(aparam == iop_ctrap) 		||
+		(aparam == iop_downscroll) 	||
+		(aparam == iop_echo) 		||
+		(aparam == iop_noecho) 		||
+		(aparam == iop_editing) 	||
+		(aparam == iop_noediting) 	||
+		(aparam == iop_escape) 		||
+		(aparam == iop_noescape) 	||
+		(aparam == iop_eraseline) 	||
+		(aparam == iop_exception) 	||
+		(aparam == iop_filter) 		||
+		(aparam == iop_nofilter) 	||
+		(aparam == iop_flush) 		||
+		(aparam == iop_hostsync) 	||
+		(aparam == iop_nohostsync) 	||
+		(aparam == iop_hupenable) 	||
+		(aparam == iop_nohupenable) 	||
+		(aparam == iop_insert) 		||
+		(aparam == iop_noinsert) 	||
+		(aparam == iop_length) 		||
+		(aparam == iop_pasthru) 	||
+		(aparam == iop_nopasthru) 	||
+		(aparam == iop_readsync) 	||
+		(aparam == iop_noreadsync) 	||
+		(aparam == iop_terminator) 	||
+		(aparam == iop_noterminator) 	||
+		(aparam == iop_ttsync) 		||
+		(aparam == iop_nottsync) 	||
+		(aparam == iop_typeahead) 	||
+		(aparam == iop_notypeahead) 	||
+		(aparam == iop_upscroll) 	||
+		(aparam == iop_width) 		||
+		(aparam == iop_wrap) 		||
+		(aparam == iop_nowrap) 		||
+		(aparam == iop_x) 		||
+		(aparam == iop_y) 		||
+		(aparam == iop_ipchset) 	||
+		(aparam == iop_opchset) 	||
+		(aparam == iop_chset)	  	||
+		//---- below are sometimes added to devparams in io_init, but apparently not processed.
+		(aparam == iop_newversion)	||
+		(aparam == iop_stream)		||
+		(aparam == iop_nl)		||
+		(aparam == iop_shared)		||
+		(aparam == iop_readonly)		);
+
+	return result;
+}
+
+void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval * devparms, devparam_validator is_valid_dev_param 		)
+//kt NOTE: This saves the IO state into ydb data structures, based on OPEN and USE parameters.
+//         AND it may also do some actions, if param calls for action.
+//	   It does NOT write anything out to the TTY IO subsystem.
+{
+	int			p_offset, fil_type, status;
+	int4			len, length, width;
+	int4			do_nothing;
+	unsigned char		ch;
+	io_params_type		aparam;
+	char			dc1;
+	char *			ttab;
+	gtm_chset_t		temp_chset, old_ichset;
+	d_tt_struct *		temp_ptr;
+	d_tt_struct * 		tt_ptr;
+	struct sigaction	act;
+	io_desc	*		d_in;
+	io_desc	*		d_out;
+	io_termmask		mask_term;
+	mstr			chset_mstr;
+	boolean_t		dev_is_tt;
+	boolean_t		flush_input = FALSE;
+	boolean_t		terminator_specified = FALSE;
+	DCL_THREADGBL_ACCESS;
+
+	SETUP_THREADGBL_ACCESS;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+	d_in = io_ptr->pair.in;
+	d_out = io_ptr->pair.out;
+	temp_ptr = (d_tt_struct *)d_in->dev_sp;
+	dev_is_tt = (tt == d_in->type); 			//kt added
+	mask_term = temp_ptr->io_state.mask_term;
+	old_ichset = io_ptr->ichset;
+	p_offset = 0;
+
+	while (iop_eol != (ch = *(devparms->str.addr + p_offset++)))
+	{
+		aparam = (io_params_type)ch;
+		if (is_valid_dev_param(aparam))
 		{
-			save_errno = errno;
-			ISSUE_NOPRINCIO_BEFORE_RTS_ERROR_IF_APPROPRIATE(iod);
-			RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCGETATTR, 1, tt_ptr->fildes, save_errno);
-		}
-		flush_input = FALSE;
-		d_in = iod->pair.in;
-		d_out = iod->pair.out;
-		temp_ptr = (d_tt_struct *)d_in->dev_sp;
-		mask_in = temp_ptr->term_ctrl;
-		mask_term = temp_ptr->mask_term;
-		old_ichset = iod->ichset;
-		while (*(pp->str.addr + p_offset) != iop_eol)
-		{
-			switch (ch = *(pp->str.addr + p_offset++))
+			switch(aparam)
 			{
 				case iop_canonical:
-					tt_ptr->canonical = TRUE;
-					t.c_lflag |= ICANON;
+					io_state_ptr->canonical = TRUE;
 					break;
 				case iop_nocanonical:
-					tt_ptr->canonical = FALSE;
-					t.c_lflag &= ~(ICANON);
+					io_state_ptr->canonical = FALSE;
 					break;
 				case iop_empterm:
-					tt_ptr->ext_cap |= TT_EMPTERM;
+					SET_BIT_FLAG_ON(TT_EMPTERM, io_state_ptr->ext_cap);
 					break;
 				case iop_noempterm:
-					tt_ptr->ext_cap &= ~TT_EMPTERM;
+					SET_BIT_FLAG_OFF(TT_EMPTERM, io_state_ptr->ext_cap);
 					break;
 				case iop_cenable:
 					/* Note that this parameter is ignored in callin/simpleapi mode because ^C in this mode
@@ -211,13 +327,13 @@ void iott_use(io_desc *iod, mval *pp)
 						gtm_tputs(CLR_EOS, 1, outc);
 					break;
 				case iop_convert:
-					mask_in |= TRM_CONVERT;
+					if (dev_is_tt) io_state_ptr->case_convert = TRUE;  			//kt mod
 					break;
 				case iop_noconvert:
-					mask_in &= ~TRM_CONVERT;
+					if (dev_is_tt) io_state_ptr->case_convert = FALSE;  			//kt mod
 					break;
 				case iop_ctrap:
-					GET_LONG(tt_ptr->enbld_outofbands.mask, pp->str.addr + p_offset);
+					GET_LONG(tt_ptr->enbld_outofbands.mask, devparms->str.addr + p_offset);
 					if (!ctrlc_on)
 					{	/* if cenable, ctrlc_handler active anyway, otherwise, depends on ctrap=$c(3) */
 						sigemptyset(&act.sa_mask);
@@ -239,38 +355,37 @@ void iott_use(io_desc *iod, mval *pp)
 					}
 					break;
 				case iop_echo:
-					mask_in &= (~TRM_NOECHO);
+					if (dev_is_tt) io_state_ptr->devparam_echo = TRUE;  			//kt added
 					break;
 				case iop_noecho:
-					mask_in |= TRM_NOECHO;
+					if (dev_is_tt) io_state_ptr->devparam_echo = FALSE;  			//kt added
 					break;
 				case iop_editing:
-					if (io_curr_device.in == io_std_device.in)
-					{	/* $PRINCIPAL only */
-						tt_ptr->ext_cap |= TT_EDITING;
+					if (io_curr_device.in == io_std_device.in)     //$PRINCIPAL only
+					{
+						SET_BIT_FLAG_ON(TT_EDITING, io_state_ptr->ext_cap);   		//kt mod
 					}
 					break;
 				case iop_noediting:
-					if (io_curr_device.in == io_std_device.in)
-						tt_ptr->ext_cap &= ~TT_EDITING;	/* $PRINCIPAL only */
+					if (io_curr_device.in == io_std_device.in)  // $PRINCIPAL only
+						SET_BIT_FLAG_OFF(TT_EDITING, io_state_ptr->ext_cap);   		//kt mod
 					break;
 				case iop_escape:
-					mask_in |= TRM_ESCAPE;
+					if (dev_is_tt) io_state_ptr->escape_processing = TRUE;
 					break;
 				case iop_noescape:
-					mask_in &= (~TRM_ESCAPE);
-				default:
+					if (dev_is_tt) io_state_ptr->escape_processing = FALSE;
 					break;
 				case iop_eraseline:
 					if (NULL != CLR_EOL)
 						gtm_tputs(CLR_EOL, 1, outc);
 					break;
 				case iop_exception:
-					DEF_EXCEPTION(pp, p_offset, iod);
+					DEF_EXCEPTION(devparms, p_offset, io_ptr);
 					break;
 				case iop_filter:
-					len = *(pp->str.addr + p_offset);
-					ttab = pp->str.addr + p_offset + 1;
+					len = *(devparms->str.addr + p_offset);
+					ttab = devparms->str.addr + p_offset + 1;
 					if ((fil_type = namelook(filter_index, filter_names, ttab, len)) < 0)
 					{
 						rts_error_csa(CSA_ARG(NULL) VARLSTCNT(1) ERR_TTINVFILTER);
@@ -279,30 +394,30 @@ void iott_use(io_desc *iod, mval *pp)
 					switch (fil_type)
 					{
 						case 0:
-							iod->write_filter |= CHAR_FILTER;
+							SET_BIT_FLAG_ON(CHAR_FILTER, io_ptr->write_filter);
 							break;
 						case 1:
-							iod->write_filter |= ESC1;
+							SET_BIT_FLAG_ON(ESC1, io_ptr->write_filter);
 							break;
 						case 2:
-							iod->write_filter &= ~CHAR_FILTER;
+							SET_BIT_FLAG_OFF(CHAR_FILTER, io_ptr->write_filter);
 							break;
 						case 3:
-							iod->write_filter &= ~ESC1;
+							SET_BIT_FLAG_OFF(ESC1, io_ptr->write_filter);
 							break;
 					}
 					break;
 				case iop_nofilter:
-					iod->write_filter = 0;
+					io_ptr->write_filter = 0;
 					break;
 				case iop_flush:
 					flush_input = TRUE;
 					break;
 				case iop_hostsync:
-					t.c_iflag |= IXOFF;
+					io_state_ptr->hostsync = TRUE;   					//kt mod
 					break;
 				case iop_nohostsync:
-					t.c_iflag &= ~IXOFF;
+					io_state_ptr->hostsync = FALSE;  					//kt mod
 					break;
 				case iop_hupenable:
 					if (!hup_on)
@@ -316,12 +431,12 @@ void iott_use(io_desc *iod, mval *pp)
 								act.sa_flags = YDB_SIGACTION_FLAGS;
 								act.sa_sigaction = ctrlc_handler_ptr;
 								sigaction(SIGHUP, &act, 0);
-													} else
+							} else
 							{
 								SET_ALTERNATE_SIGHANDLER(SIGHUP, &ydb_altmain_sighandler);
 							}
 							hup_on = TRUE;
-}
+						}
 					}
 					break;
 				case iop_nohupenable:
@@ -345,27 +460,27 @@ void iott_use(io_desc *iod, mval *pp)
 					}
 					break;
 				case iop_insert:
-					if (io_curr_device.in == io_std_device.in)
-						tt_ptr->ext_cap &= ~TT_NOINSERT;	/* $PRINCIPAL only */
+					if (io_curr_device.in == io_std_device.in)		// $PRINCIPAL only
+						SET_BIT_FLAG_OFF(TT_NOINSERT, io_state_ptr->ext_cap);		//kt mod turning OFF NOINSERT --> turns ON insert
 					break;
 				case iop_noinsert:
-					if (io_curr_device.in == io_std_device.in)
-						tt_ptr->ext_cap |= TT_NOINSERT;	/* $PRINCIPAL only */
+					if (io_curr_device.in == io_std_device.in)		//  $PRINCIPAL only
+						SET_BIT_FLAG_ON(TT_NOINSERT, io_state_ptr->ext_cap);		//kt mod turning ON NOINSERT --> turns OFF insert
 					break;
 				case iop_length:
-					GET_LONG(length, pp->str.addr + p_offset);
+					GET_LONG(length, devparms->str.addr + p_offset);
 					if (0 > length)
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(1) ERR_DEVPARMNEG);
 					d_out->length = length;
 					break;
 				case iop_pasthru:
-					mask_in |= TRM_PASTHRU;
+					if (dev_is_tt) io_state_ptr->passthru = TRUE;   			//kt mod
 					break;
 				case iop_nopasthru:
-					mask_in &= (~TRM_PASTHRU);
+					if (dev_is_tt) io_state_ptr->passthru = FALSE;  			//kt mod
 					break;
 				case iop_readsync:
-					mask_in |= TRM_READSYNC;
+					if (dev_is_tt) io_state_ptr->readsync = TRUE;
 					break;
 				case iop_noreadsync:
 					dc1 = (char)17;
@@ -373,40 +488,30 @@ void iott_use(io_desc *iod, mval *pp)
 					DOWRITERC(temp_ptr->fildes, &dc1, 1, status);
 					if (0 != status)
 						rts_error_csa(CSA_ARG(NULL) VARLSTCNT(1) status);
-					mask_in &= (~TRM_READSYNC);
+					if (dev_is_tt) io_state_ptr->readsync = FALSE;
 					break;
 				case iop_terminator:
-					memcpy(&mask_term.mask[0], (pp->str.addr + p_offset), SIZEOF(io_termmask));
+					memcpy(&mask_term.mask[0], (devparms->str.addr + p_offset), SIZEOF(io_termmask));
 					terminator_specified = TRUE;
 					temp_ptr = (d_tt_struct *)d_in->dev_sp;
-					if (mask_term.mask[0] == NUL &&
-					    mask_term.mask[1] == NUL &&
-					    mask_term.mask[2] == NUL &&
-					    mask_term.mask[3] == NUL &&
-					    mask_term.mask[4] == NUL &&
-					    mask_term.mask[5] == NUL &&
-					    mask_term.mask[6] == NUL &&
-					    mask_term.mask[7] == NUL)
-						temp_ptr->default_mask_term = TRUE;
-					else
-						temp_ptr->default_mask_term = FALSE;
+					temp_ptr->io_state.default_mask_term = (STRUCTS_ARE_EQUAL(mask_term, NULL_TERM_MASK));
 					break;
 				case iop_noterminator:
 					temp_ptr = (d_tt_struct *)d_in->dev_sp;
-					temp_ptr->default_mask_term = FALSE;
-					memset(&mask_term.mask[0], 0, SIZEOF(io_termmask));
+					temp_ptr->io_state.default_mask_term = FALSE;
+					mask_term = NULL_TERM_MASK;  						//kt mod
 					break;
 				case iop_ttsync:
-					t.c_iflag |= IXON;
+					if (dev_is_tt) io_state_ptr->ttsync = TRUE;  	 			//kt mod
 					break;
 				case iop_nottsync:
-					t.c_iflag &= ~IXON;
+					if (dev_is_tt) io_state_ptr->ttsync = FALSE; ;  			//kt mod
 					break;
 				case iop_typeahead:
-					mask_in &= (~TRM_NOTYPEAHD);
+					if (dev_is_tt) io_state_ptr->no_type_ahead = FALSE; 			//kt mod
 					break;
 				case iop_notypeahead:
-					mask_in |= TRM_NOTYPEAHD;
+					if (dev_is_tt) io_state_ptr->no_type_ahead = TRUE; 			//kt mod
 					break;
 				case iop_upscroll:
 					d_out->dollar.y++;
@@ -416,7 +521,7 @@ void iott_use(io_desc *iod, mval *pp)
 						gtm_tputs(gtm_tparm(CURSOR_ADDRESS, d_out->dollar.y, d_out->dollar.x), 1, outc);
 					break;
 				case iop_width:
-					GET_LONG(width, pp->str.addr + p_offset);
+					GET_LONG(width, devparms->str.addr + p_offset);
 					if (0 > width)
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(1) ERR_DEVPARMNEG);
 					/* Do not allow a WIDTH of 1 if UTF mode (ICHSET or OCHSET is not M) */
@@ -439,7 +544,7 @@ void iott_use(io_desc *iod, mval *pp)
 					d_out->wrap = FALSE;
 					break;
 				case iop_x:
-					GET_LONG(d_out->dollar.x, pp->str.addr + p_offset);
+					GET_LONG(d_out->dollar.x, devparms->str.addr + p_offset);
 					if (0 > (int4)d_out->dollar.x)
 						d_out->dollar.x = 0;
 					if (d_out->dollar.x > d_out->width && d_out->wrap)
@@ -453,7 +558,7 @@ void iott_use(io_desc *iod, mval *pp)
 						gtm_tputs(gtm_tparm(CURSOR_ADDRESS, d_out->dollar.y, d_out->dollar.x), 1, outc);
 					break;
 				case iop_y:
-					GET_LONG(d_out->dollar.y, pp->str.addr + p_offset);
+					GET_LONG(d_out->dollar.y, devparms->str.addr + p_offset);
 					if (0 > (int4)d_out->dollar.y)
 						d_out->dollar.y = 0;
 					if (d_out->length)
@@ -463,111 +568,132 @@ void iott_use(io_desc *iod, mval *pp)
 					break;
 				case iop_ipchset:
 				{
-#						ifdef KEEP_zOS_EBCDIC
-					if ((iconv_t)0 != iod->input_conv_cd)
+#					ifdef KEEP_zOS_EBCDIC
+					if ((iconv_t)0 != io_ptr->input_conv_cd)
 					{
-						ICONV_CLOSE_CD(iod->input_conv_cd);
+						ICONV_CLOSE_CD(io_ptr->input_conv_cd);
 					}
-					SET_CODE_SET(iod->in_code_set, (char *)(pp->str.addr + p_offset + 1));
-					if (DEFAULT_CODE_SET != iod->in_code_set)
-						ICONV_OPEN_CD(iod->input_conv_cd,
-							      (char *)(pp->str.addr + p_offset + 1), INSIDE_CH_SET);
-#						endif
-					GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+					SET_CODE_SET(io_ptr->in_code_set, (char *)(devparms->str.addr + p_offset + 1));
+					if (DEFAULT_CODE_SET != io_ptr->in_code_set)
+						ICONV_OPEN_CD(io_ptr->input_conv_cd,
+							      (char *)(devparms->str.addr + p_offset + 1), INSIDE_CH_SET);
+#					endif
+					GET_ADDR_AND_LEN_V2(devparms, p_offset, chset_mstr.addr, chset_mstr.len);	//kt mod
 					SET_ENCODING(temp_chset, &chset_mstr);
 					if (!gtm_utf8_mode && IS_UTF_CHSET(temp_chset))
 						break;	/* ignore UTF chsets if not utf8_mode. */
 					if (IS_UTF16_CHSET(temp_chset))		/* UTF16 is not valid for TTY */
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_BADCHSET, 2,
 							      chset_mstr.len, chset_mstr.addr);
-					iod->ichset = temp_chset;
+					io_ptr->ichset = temp_chset;
 					break;
 				}
 				case iop_opchset:
 				{
-#						ifdef KEEP_zOS_EBCDIC
-					if ((iconv_t)0 != iod->output_conv_cd)
+#					ifdef KEEP_zOS_EBCDIC
+					if ((iconv_t)0 != io_ptr->output_conv_cd)
 					{
-						ICONV_CLOSE_CD(iod->output_conv_cd);
+						ICONV_CLOSE_CD(io_ptr->output_conv_cd);
 					}
-					SET_CODE_SET(iod->out_code_set, (char *)(pp->str.addr + p_offset + 1));
-					if (DEFAULT_CODE_SET != iod->out_code_set)
-						ICONV_OPEN_CD(iod->output_conv_cd, INSIDE_CH_SET,
-							      (char *)(pp->str.addr + p_offset + 1));
-#						endif
-					GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+					SET_CODE_SET(io_ptr->out_code_set, (char *)(devparms->str.addr + p_offset + 1));
+					if (DEFAULT_CODE_SET != io_ptr->out_code_set)
+						ICONV_OPEN_CD(io_ptr->output_conv_cd, INSIDE_CH_SET,
+							      (char *)(devparms->str.addr + p_offset + 1));
+#					endif
+					GET_ADDR_AND_LEN_V2(devparms, p_offset, chset_mstr.addr, chset_mstr.len);	//kt mod
 					SET_ENCODING(temp_chset, &chset_mstr);
 					if (!gtm_utf8_mode && IS_UTF_CHSET(temp_chset))
 						break;	/* ignore UTF chsets if not utf8_mode. */
 					if (IS_UTF16_CHSET(temp_chset))		/* UTF16 is not valid for TTY */
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_BADCHSET, 2,
 							      chset_mstr.len, chset_mstr.addr);
-					iod->ochset = temp_chset;
+					io_ptr->ochset = temp_chset;
 					break;
 				}
 				case iop_chset:
 				{
-					GET_ADDR_AND_LEN(chset_mstr.addr, chset_mstr.len);
+					GET_ADDR_AND_LEN_V2(devparms, p_offset, chset_mstr.addr, chset_mstr.len);	//kt mod
 					SET_ENCODING(temp_chset, &chset_mstr);
 					if (!gtm_utf8_mode && IS_UTF_CHSET(temp_chset))
 						break;	/* ignore UTF chsets if not utf8_mode. */
 					if (IS_UTF16_CHSET(temp_chset))		/* UTF16 is not valid for TTY */
 						RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_BADCHSET, 2,
 							      chset_mstr.len, chset_mstr.addr);
-					iod->ichset = iod->ochset = temp_chset;
+					io_ptr->ichset = io_ptr->ochset = temp_chset;
 					break;
 				}
+				//---- below exclusively from iott_open params
+				case iop_m:
+					io_ptr->ichset = io_ptr->ochset = CHSET_M;
+					break;
+				case iop_utf8:
+					if (gtm_utf8_mode)
+						io_ptr->ichset = io_ptr->ochset = CHSET_UTF8;
+					break;
+				//---- below are sometimes added to devparams in io_init, but apparently not processed.
+				case iop_newversion:
+					do_nothing = 1; //kt added.  Just a stopping place for debugger
+					break;
+				case iop_stream:
+					do_nothing = 2; //kt added  Just a stopping place for debugger
+					break;
+				case iop_nl:
+					do_nothing = 3; //kt added  Just a stopping place for debugger
+					break;
+				case iop_shared:
+					do_nothing = 4; //kt added  Just a stopping place for debugger
+					break;
+				case iop_readonly:
+					do_nothing = 5; //kt added  Just a stopping place for debugger
+					break;
+				default:
+					break;
 			}
-			UPDATE_P_OFFSET(p_offset, ch, pp);	/* updates "p_offset" using "ch" and "pp" */
 		}
-		temp_ptr = (d_tt_struct *)d_in->dev_sp;
-		Tcsetattr(tt_ptr->fildes, TCSANOW, &t, status, save_errno, CHANGE_TERM_TRUE);
+		UPDATE_P_OFFSET(p_offset, ch, devparms);	// updates "p_offset" using "ch" and "devparms"
+	}
+
+	if (flush_input)
+	{
+		TCFLUSH(tt_ptr->fildes, TCIFLUSH, status);
 		if (0 != status)
 		{
-			assert(WBTEST_YDB_KILL_TERMINAL == ydb_white_box_test_case_number);
-			ISSUE_NOPRINCIO_BEFORE_RTS_ERROR_IF_APPROPRIATE(iod);
-			RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(4) ERR_TCSETATTR, 1, tt_ptr->fildes, save_errno);
-		}
-		/* Store both t.c_lflag and t.c_iflag back in tt_ptr after calling Tcsetattr */
-		/* t.c_iflag used for show TTSYNC and NOTTSYNC when using ZSHOW "D" */
-		/* we may not need t.c_lflag because tt_ptr->canonical is currently responsible for CANONICAL output */
-		/* in sr_unix/zshow_devices.c but we might need it later so just store it both just in case */
-		tt_ptr->ttio_struct->c_iflag = t.c_lflag;
-		tt_ptr->ttio_struct->c_iflag = t.c_iflag;
-		if (tt == d_in->type)
-		{
-			temp_ptr->term_ctrl = mask_in;
-			/* reset the mask to default if chset was changed without specifying new terminators or Default */
-			if ((!terminator_specified && (old_ichset != iod->ichset)) ||
-			    (terminator_specified && temp_ptr->default_mask_term))
-			{
-				memset(&mask_term.mask[0], 0, SIZEOF(io_termmask));
-				if (CHSET_M != iod->ichset)
-				{
-					mask_term.mask[0] = TERM_MSK_UTF8_0;
-					mask_term.mask[4] = TERM_MSK_UTF8_4;
-				} else
-					mask_term.mask[0] = TERM_MSK;
-				temp_ptr->default_mask_term = TRUE;
-			}
-			memcpy(&temp_ptr->mask_term, &mask_term, SIZEOF(io_termmask));
-		}
-		if (flush_input)
-		{
-			TCFLUSH(tt_ptr->fildes, TCIFLUSH, status);
-			if (0 != status)
-			{
-				ISSUE_NOPRINCIO_BEFORE_RTS_ERROR_IF_APPROPRIATE(iod);
-				RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(8) ERR_SYSCALL, 5, LEN_AND_LIT("tcflush input"),
+			ISSUE_NOPRINCIO_BEFORE_RTS_ERROR_IF_APPROPRIATE(io_ptr);
+			RTS_ERROR_CSA_ABT(NULL, VARLSTCNT(8) ERR_SYSCALL, 5, LEN_AND_LIT("tcflush input"),
 					      CALLFROM, errno);
-			}
 		}
-	} else if (tt_ptr->mupintr && !dollar_zininterrupt)
-	{	/* The interrupted read was not properly resumed so clear it now */
-		tt_ptr->mupintr = FALSE;
-		tt_ptr->tt_state_save.who_saved = ttwhichinvalid;
-		io_find_mvstent(iod, TRUE);	/* clear mv stack entry */
 	}
-	REVERT_GTMIO_CH(&iod->pair, ch_set);
-	return;
+
+	if (dev_is_tt)
+	{
+		/* if chset was changed without specifying new terminators or Default, then reset the mask to default  */
+		if ((!terminator_specified && (old_ichset != io_ptr->ichset)) 		||
+		    ( terminator_specified && (tt_ptr->io_state.default_mask_term)))
+		{
+			iott_set_mask_term_conditional(io_ptr, &mask_term, (CHSET_M != io_ptr->ichset), TRUE);  //kt
+		}
+		tt_ptr->io_state.mask_term = mask_term;  //kt
+	}
+}
+
+void iott_set_mask_term_conditional(io_desc* io_ptr, io_termmask*  mask_term_ptr, boolean_t bool_test, boolean_t set_default)
+//kt added function, combining duplicate code.
+{
+	d_tt_struct * 		tt_ptr;
+	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+
+	*mask_term_ptr = NULL_TERM_MASK;
+	if (bool_test)
+	{
+		mask_term_ptr->mask[0] = TERM_MSK_UTF8_0;
+		mask_term_ptr->mask[4] = TERM_MSK_UTF8_4;
+	} else
+	{
+		mask_term_ptr->mask[0] = TERM_MSK;
+	}
+	if (set_default)
+	{
+		tt_ptr->io_state.default_mask_term = TRUE;
+	}
+
 }

--- a/sr_unix/iott_use.c
+++ b/sr_unix/iott_use.c
@@ -67,7 +67,7 @@ LITDEF unsigned char filter_index[27] =
 	,4, 4, 4
 };
 
-const io_termmask NULL_TERM_MASK = { {0, 0, 0, 0, 0, 0, 0, 0} };   //kt added
+const io_termmask NULL_TERM_MASK = { {0, 0, 0, 0, 0, 0, 0, 0} };
 
 GBLREF boolean_t		ctrlc_on, hup_on, prin_in_dev_failure, prin_out_dev_failure;
 GBLREF char			*CURSOR_ADDRESS, *CLR_EOL, *CLR_EOS;
@@ -117,8 +117,8 @@ void iott_use(io_desc * io_ptr, mval * devparms)
 		//setup ydb IO state (but not TTY IO subsystem) based on device parameters
 		iott_use_params_to_state(io_ptr, devparms);
 
-		//kt Moved functionality of prior block of code into iott_compile_state_and_set_tty_and_ydb_echo(),
-		//kt   and calling below outside IF block, so that even if there are no devparams, it will still be called.
+		//Moved functionality of prior block of code into iott_compile_state_and_set_tty_and_ydb_echo(),
+		//  and calling below outside IF block, so that even if there are no devparams, it will still be called.
 	} else if (tt_ptr->mupintr && !dollar_zininterrupt)
 	{	/* The interrupted read was not properly resumed so clear it now */
 		tt_ptr->mupintr = FALSE;
@@ -126,15 +126,15 @@ void iott_use(io_desc * io_ptr, mval * devparms)
 		io_find_mvstent(io_ptr, TRUE);	/* clear mv stack entry */
 	}
 
-	//kt  Send IO state to TTY IO subsystem.  8 is default time, 1 is minimum chars; can be changed later.
-	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_3);   //kt added, moving funcitonality down from above.
+	//Send IO state to TTY IO subsystem.  8 is default time, 1 is minimum chars; can be changed later.
+	iott_compile_state_and_set_tty_and_ydb_echo(io_ptr, 8, 1, handle_set_tty_err_mode_3);   //Moving funcitonality down from above.
 
 	REVERT_GTMIO_CH(&io_ptr->pair, ch_set);
 	return;
 }
 
 void handle_set_tty_err_mode_3(io_desc* io_ptr, int save_errno, int filedes)  //for SET_TTY_CHECK_ERRORS_MODE_3
-//kt added
+
 {
 	assert(WBTEST_YDB_KILL_TERMINAL == ydb_white_box_test_case_number);
 	ISSUE_NOPRINCIO_BEFORE_RTS_ERROR_IF_APPROPRIATE(io_ptr);
@@ -143,9 +143,8 @@ void handle_set_tty_err_mode_3(io_desc* io_ptr, int save_errno, int filedes)  //
 
 
 void iott_use_params_to_state(io_desc * io_ptr, mval * devparms)
-//kt added function, using code from iott_use()
-//kt NOTE: This saves the IO state into ydb data structures, based on USE parameters.
-//         AND it also does some actions, if param calls for action.  It does NOT write anything out to the TTY IO subsystem.
+//NOTE: This saves the IO state into ydb data structures, based on USE parameters.
+//       AND it also does some actions, if param calls for action.  It does NOT write anything out to the TTY IO subsystem.
 {
 	d_tt_struct * 		tt_ptr;
 	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
@@ -153,7 +152,7 @@ void iott_use_params_to_state(io_desc * io_ptr, mval * devparms)
 }
 
 boolean_t iott_is_valid_use_param(io_params_type aparam)  // is aparam valid for USE command?
-//kt added function
+
 {
 	boolean_t	result;
 	result = (
@@ -216,9 +215,9 @@ boolean_t iott_is_valid_use_param(io_params_type aparam)  // is aparam valid for
 }
 
 void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval * devparms, devparam_validator is_valid_dev_param 		)
-//kt NOTE: This saves the IO state into ydb data structures, based on OPEN and USE parameters.
-//         AND it may also do some actions, if param calls for action.
-//	   It does NOT write anything out to the TTY IO subsystem.
+//NOTE: This saves the IO state into ydb data structures, based on OPEN and USE parameters.
+//       AND it may also do some actions, if param calls for action.
+//       It does NOT write anything out to the TTY IO subsystem.
 {
 	int			p_offset, fil_type, status;
 	int4			len, length, width;
@@ -245,7 +244,7 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 	d_in = io_ptr->pair.in;
 	d_out = io_ptr->pair.out;
 	temp_ptr = (d_tt_struct *)d_in->dev_sp;
-	dev_is_tt = (tt == d_in->type); 			//kt added
+	dev_is_tt = (tt == d_in->type);
 	mask_term = temp_ptr->io_state.mask_term;
 	old_ichset = io_ptr->ichset;
 	p_offset = 0;
@@ -327,10 +326,10 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 						gtm_tputs(CLR_EOS, 1, outc);
 					break;
 				case iop_convert:
-					if (dev_is_tt) io_state_ptr->case_convert = TRUE;  			//kt mod
+					if (dev_is_tt) io_state_ptr->case_convert = TRUE;
 					break;
 				case iop_noconvert:
-					if (dev_is_tt) io_state_ptr->case_convert = FALSE;  			//kt mod
+					if (dev_is_tt) io_state_ptr->case_convert = FALSE;
 					break;
 				case iop_ctrap:
 					GET_LONG(tt_ptr->enbld_outofbands.mask, devparms->str.addr + p_offset);
@@ -355,20 +354,20 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 					}
 					break;
 				case iop_echo:
-					if (dev_is_tt) io_state_ptr->devparam_echo = TRUE;  			//kt added
+					if (dev_is_tt) io_state_ptr->devparam_echo = TRUE;
 					break;
 				case iop_noecho:
-					if (dev_is_tt) io_state_ptr->devparam_echo = FALSE;  			//kt added
+					if (dev_is_tt) io_state_ptr->devparam_echo = FALSE;
 					break;
 				case iop_editing:
 					if (io_curr_device.in == io_std_device.in)     //$PRINCIPAL only
 					{
-						SET_BIT_FLAG_ON(TT_EDITING, io_state_ptr->ext_cap);   		//kt mod
+						SET_BIT_FLAG_ON(TT_EDITING, io_state_ptr->ext_cap);
 					}
 					break;
 				case iop_noediting:
 					if (io_curr_device.in == io_std_device.in)  // $PRINCIPAL only
-						SET_BIT_FLAG_OFF(TT_EDITING, io_state_ptr->ext_cap);   		//kt mod
+						SET_BIT_FLAG_OFF(TT_EDITING, io_state_ptr->ext_cap);
 					break;
 				case iop_escape:
 					if (dev_is_tt) io_state_ptr->escape_processing = TRUE;
@@ -414,10 +413,10 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 					flush_input = TRUE;
 					break;
 				case iop_hostsync:
-					io_state_ptr->hostsync = TRUE;   					//kt mod
+					io_state_ptr->hostsync = TRUE;
 					break;
 				case iop_nohostsync:
-					io_state_ptr->hostsync = FALSE;  					//kt mod
+					io_state_ptr->hostsync = FALSE;
 					break;
 				case iop_hupenable:
 					if (!hup_on)
@@ -461,11 +460,11 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 					break;
 				case iop_insert:
 					if (io_curr_device.in == io_std_device.in)		// $PRINCIPAL only
-						SET_BIT_FLAG_OFF(TT_NOINSERT, io_state_ptr->ext_cap);		//kt mod turning OFF NOINSERT --> turns ON insert
+						SET_BIT_FLAG_OFF(TT_NOINSERT, io_state_ptr->ext_cap);		//turning OFF NOINSERT --> turns ON insert
 					break;
 				case iop_noinsert:
 					if (io_curr_device.in == io_std_device.in)		//  $PRINCIPAL only
-						SET_BIT_FLAG_ON(TT_NOINSERT, io_state_ptr->ext_cap);		//kt mod turning ON NOINSERT --> turns OFF insert
+						SET_BIT_FLAG_ON(TT_NOINSERT, io_state_ptr->ext_cap);		//turning ON NOINSERT --> turns OFF insert
 					break;
 				case iop_length:
 					GET_LONG(length, devparms->str.addr + p_offset);
@@ -474,10 +473,10 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 					d_out->length = length;
 					break;
 				case iop_pasthru:
-					if (dev_is_tt) io_state_ptr->passthru = TRUE;   			//kt mod
+					if (dev_is_tt) io_state_ptr->passthru = TRUE;
 					break;
 				case iop_nopasthru:
-					if (dev_is_tt) io_state_ptr->passthru = FALSE;  			//kt mod
+					if (dev_is_tt) io_state_ptr->passthru = FALSE;
 					break;
 				case iop_readsync:
 					if (dev_is_tt) io_state_ptr->readsync = TRUE;
@@ -499,19 +498,19 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 				case iop_noterminator:
 					temp_ptr = (d_tt_struct *)d_in->dev_sp;
 					temp_ptr->io_state.default_mask_term = FALSE;
-					mask_term = NULL_TERM_MASK;  						//kt mod
+					mask_term = NULL_TERM_MASK;
 					break;
 				case iop_ttsync:
-					if (dev_is_tt) io_state_ptr->ttsync = TRUE;  	 			//kt mod
+					if (dev_is_tt) io_state_ptr->ttsync = TRUE;
 					break;
 				case iop_nottsync:
-					if (dev_is_tt) io_state_ptr->ttsync = FALSE; ;  			//kt mod
+					if (dev_is_tt) io_state_ptr->ttsync = FALSE; ;
 					break;
 				case iop_typeahead:
-					if (dev_is_tt) io_state_ptr->no_type_ahead = FALSE; 			//kt mod
+					if (dev_is_tt) io_state_ptr->no_type_ahead = FALSE;
 					break;
 				case iop_notypeahead:
-					if (dev_is_tt) io_state_ptr->no_type_ahead = TRUE; 			//kt mod
+					if (dev_is_tt) io_state_ptr->no_type_ahead = TRUE;
 					break;
 				case iop_upscroll:
 					d_out->dollar.y++;
@@ -578,7 +577,7 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 						ICONV_OPEN_CD(io_ptr->input_conv_cd,
 							      (char *)(devparms->str.addr + p_offset + 1), INSIDE_CH_SET);
 #					endif
-					GET_ADDR_AND_LEN_V2(devparms, p_offset, chset_mstr.addr, chset_mstr.len);	//kt mod
+					GET_ADDR_AND_LEN_V2(devparms, p_offset, chset_mstr.addr, chset_mstr.len);
 					SET_ENCODING(temp_chset, &chset_mstr);
 					if (!gtm_utf8_mode && IS_UTF_CHSET(temp_chset))
 						break;	/* ignore UTF chsets if not utf8_mode. */
@@ -600,7 +599,7 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 						ICONV_OPEN_CD(io_ptr->output_conv_cd, INSIDE_CH_SET,
 							      (char *)(devparms->str.addr + p_offset + 1));
 #					endif
-					GET_ADDR_AND_LEN_V2(devparms, p_offset, chset_mstr.addr, chset_mstr.len);	//kt mod
+					GET_ADDR_AND_LEN_V2(devparms, p_offset, chset_mstr.addr, chset_mstr.len);
 					SET_ENCODING(temp_chset, &chset_mstr);
 					if (!gtm_utf8_mode && IS_UTF_CHSET(temp_chset))
 						break;	/* ignore UTF chsets if not utf8_mode. */
@@ -612,7 +611,7 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 				}
 				case iop_chset:
 				{
-					GET_ADDR_AND_LEN_V2(devparms, p_offset, chset_mstr.addr, chset_mstr.len);	//kt mod
+					GET_ADDR_AND_LEN_V2(devparms, p_offset, chset_mstr.addr, chset_mstr.len);
 					SET_ENCODING(temp_chset, &chset_mstr);
 					if (!gtm_utf8_mode && IS_UTF_CHSET(temp_chset))
 						break;	/* ignore UTF chsets if not utf8_mode. */
@@ -632,19 +631,19 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 					break;
 				//---- below are sometimes added to devparams in io_init, but apparently not processed.
 				case iop_newversion:
-					do_nothing = 1; //kt added.  Just a stopping place for debugger
+					do_nothing = 1; //Just a stopping place for debugger
 					break;
 				case iop_stream:
-					do_nothing = 2; //kt added  Just a stopping place for debugger
+					do_nothing = 2; //Just a stopping place for debugger
 					break;
 				case iop_nl:
-					do_nothing = 3; //kt added  Just a stopping place for debugger
+					do_nothing = 3; //Just a stopping place for debugger
 					break;
 				case iop_shared:
-					do_nothing = 4; //kt added  Just a stopping place for debugger
+					do_nothing = 4; //Just a stopping place for debugger
 					break;
 				case iop_readonly:
-					do_nothing = 5; //kt added  Just a stopping place for debugger
+					do_nothing = 5; //Just a stopping place for debugger
 					break;
 				default:
 					break;
@@ -670,14 +669,13 @@ void iott_common_params_to_state(io_desc* io_ptr, ttio_state* io_state_ptr, mval
 		if ((!terminator_specified && (old_ichset != io_ptr->ichset)) 		||
 		    ( terminator_specified && (tt_ptr->io_state.default_mask_term)))
 		{
-			iott_set_mask_term_conditional(io_ptr, &mask_term, (CHSET_M != io_ptr->ichset), TRUE);  //kt
+			iott_set_mask_term_conditional(io_ptr, &mask_term, (CHSET_M != io_ptr->ichset), TRUE);
 		}
-		tt_ptr->io_state.mask_term = mask_term;  //kt
+		tt_ptr->io_state.mask_term = mask_term;
 	}
 }
 
 void iott_set_mask_term_conditional(io_desc* io_ptr, io_termmask*  mask_term_ptr, boolean_t bool_test, boolean_t set_default)
-//kt added function, combining duplicate code.
 {
 	d_tt_struct * 		tt_ptr;
 	tt_ptr = (d_tt_struct *)io_ptr->dev_sp;

--- a/sr_unix/iottdef.h
+++ b/sr_unix/iottdef.h
@@ -41,7 +41,7 @@
 #define TT_NOINSERT		0x2000
 #define TT_EMPTERM		0x4000
 
-//kt BEGIN additions -----------------------------------------------------------------------------------
+//BEGIN additions -----------------------------------------------------------------------------------
 
 typedef int tty_getsetattr_status;
 #define GETSETATTR_SUCCESS  0
@@ -109,7 +109,7 @@ MBSTART { 											\
 	 LEN = (int)(*(STRUCT)->str.addr + OFFSET);        					\
      }
 
-//kt END additions -----------------------------------------------------------------------------------
+//END additions -----------------------------------------------------------------------------------
 
 
 #define TERMHUP_NOPRINCIO_CHECK(WRITE)								\
@@ -230,7 +230,7 @@ typedef struct
 				 */
 } recall_ctxt_t;
 
-//kt begin addition ----------
+//Begin addition ----------
 // This struct will hold everything related to a particular TTY IO state of a device.
 // See also additional documentation in iott_compile_ttio_struct() in setterm.c
 // For TTY IO signals that are never modified by YDB, e.g. ISIG (enable signals), the state will not
@@ -257,7 +257,7 @@ typedef struct
 	boolean_t		escape_processing;	/* store ESCAPE state.  Enables or disables YottaDB processing of escape sequences.*/
 	boolean_t		default_mask_term;	/* mask_term is the default */
 } ttio_state;
-//kt end addition ----------
+//End addition ----------
 
 
 typedef struct
@@ -267,9 +267,9 @@ typedef struct
 	uint4			ext_cap;
 	io_terminator		enbld_outofbands; 	/* enabled out-of-band chars	*/
 	int			fildes;
-	ttio_state		io_state;		//kt added -- IO state based on latest USE or OPEN device parameters
-	ttio_state		initial_io_state;	//kt added -- IO state from when ydb first started
-	ttio_state		direct_mode_io_state;	//kt added -- IO state for use when interacting with user in direct mode
+	ttio_state		io_state;		//IO state based on latest USE or OPEN device parameters
+	ttio_state		initial_io_state;	//IO state from when ydb first started
+	ttio_state		direct_mode_io_state;	//IO state for use when interacting with user in direct mode
 	tt_interrupt		tt_state_save;		/* in case job interrupt */
 	boolean_t		mupintr;		/* read was interrupted */
 	char			*ttybuff;		/* buffer for tty */
@@ -295,7 +295,7 @@ void iott_readfl_badchar(mval *vmvalptr, wint_t *dataptr32, int datalen,
 			 int delimlen, unsigned char *delimptr, unsigned char *strend, unsigned char *buffer_start);
 void	iott_recall_array_add(d_tt_struct *tt_ptr, int nchars, int width, int bytelen, void *ptr);
 
-//BEGIN ADDITIONS BY //kt --------------------------------------------------------------------------------------------------------------
+//BEGIN ADDITIONS  --------------------------------------------------------------------------------------------------------------
 typedef enum io_params io_params_type;
 typedef boolean_t (*devparam_validator)(io_params_type aparam);
 typedef void (*set_tty_err_handler)(io_desc* io_ptr, int save_errno, int filedes);
@@ -322,6 +322,6 @@ void handle_set_tty_err_mode_2(io_desc* io_ptr, int save_errno, int filedes);
 void handle_set_tty_err_mode_3(io_desc* io_ptr, int save_errno, int filedes);
 void handle_reset_tty_err(io_desc* io_ptr, int save_errno, int filedes);
 
-//END ADDITIONS BY //kt --------------------------------------------------------------------------------------------------------------
+//END ADDITIONS --------------------------------------------------------------------------------------------------------------
 
 #endif

--- a/sr_unix/readline.c
+++ b/sr_unix/readline.c
@@ -798,7 +798,7 @@ int readline_startup_hook(void) {
 	*vrl_already_prompted = 0;
 
 	/* Insert mode from ydb_principal_editing="[NO]INSERT" */
-	insert_mode = !(TT_NOINSERT & tt_ptr->ext_cap);
+	insert_mode = BIT_FLAG_IS_OFF(TT_NOINSERT, tt_ptr->io_state.ext_cap); 		//kt mod
 	if (!insert_mode) {
 		/* Activate OVERWRITE mode */
 		frl_overwrite_mode(1,0);

--- a/sr_unix/readline.c
+++ b/sr_unix/readline.c
@@ -798,7 +798,7 @@ int readline_startup_hook(void) {
 	*vrl_already_prompted = 0;
 
 	/* Insert mode from ydb_principal_editing="[NO]INSERT" */
-	insert_mode = BIT_FLAG_IS_OFF(TT_NOINSERT, tt_ptr->io_state.ext_cap); 		//kt mod
+	insert_mode = BIT_FLAG_IS_OFF(TT_NOINSERT, tt_ptr->io_state.ext_cap);
 	if (!insert_mode) {
 		/* Activate OVERWRITE mode */
 		frl_overwrite_mode(1,0);

--- a/sr_unix/zshow_devices.c
+++ b/sr_unix/zshow_devices.c
@@ -256,29 +256,29 @@ void zshow_devices(zshow_out *output)
 						ZS_ONE_OUT(&v, rparen_text);
 						ZS_ONE_OUT(&v, space_text);
 					}
-					if (tt_ptr->io_state.devparam_echo == FALSE)  //kt mod
+					if (tt_ptr->io_state.devparam_echo == FALSE)
 					{
 						ZS_PARM_SP(&v, zshow_noecho);
 					}
-					if (tt_ptr->io_state.passthru == TRUE)  //kt mod.
+					if (tt_ptr->io_state.passthru == TRUE)
 					{
 						ZS_PARM_SP(&v, zshow_past);
 					} else
 					{
 						ZS_PARM_SP(&v, zshow_nopast);
 					}
-					if (!(tt_ptr->io_state.escape_processing))  //kt mod.
+					if (!(tt_ptr->io_state.escape_processing))
 					{
 						ZS_PARM_SP(&v, zshow_noesca);
 					}
-					if (tt_ptr->io_state.readsync == TRUE)  //kt mod.
+					if (tt_ptr->io_state.readsync == TRUE)
 					{
 						ZS_PARM_SP(&v, zshow_reads);
 					} else
 					{
 						ZS_PARM_SP(&v, zshow_noreads);
 					}
-					if (tt_ptr->io_state.no_type_ahead)  //kt mod
+					if (tt_ptr->io_state.no_type_ahead)
 					{
 						ZS_PARM_SP(&v, zshow_notype);
 					} else
@@ -289,8 +289,8 @@ void zshow_devices(zshow_out *output)
 					{
 						ZS_PARM_SP(&v, zshow_nowrap);
 					}
-					mask_out = &tt_ptr->io_state.mask_term;  //kt mod
-					if (!tt_ptr->io_state.default_mask_term)  //kt mod
+					mask_out = &tt_ptr->io_state.mask_term;
+					if (!tt_ptr->io_state.default_mask_term)
 					{
 						ZS_PARM_EQU(&v, zshow_term);
 						ZS_STR_OUT(&v,dollarc_text);
@@ -345,13 +345,13 @@ void zshow_devices(zshow_out *output)
 							ZS_ONE_OUT(&v,rparen_text);
 						ZS_ONE_OUT(&v, space_text);
 					}
-					if BIT_FLAG_IS_ON(TT_EDITING, tt_ptr->io_state.ext_cap) //kt mod
+					if BIT_FLAG_IS_ON(TT_EDITING, tt_ptr->io_state.ext_cap)
 						ZS_PARM_SP(&v, zshow_edit);
-					if BIT_FLAG_IS_ON(TT_NOINSERT, tt_ptr->io_state.ext_cap) //kt mod
+					if BIT_FLAG_IS_ON(TT_NOINSERT, tt_ptr->io_state.ext_cap)
 						ZS_PARM_SP(&v, zshow_noinse);
-					if BIT_FLAG_IS_ON(TT_EMPTERM, tt_ptr->io_state.ext_cap)  //kt mod.
+					if BIT_FLAG_IS_ON(TT_EMPTERM, tt_ptr->io_state.ext_cap)
 						ZS_PARM_SP(&v, zshow_empterm);
-					if (tt_ptr->io_state.canonical)	//kt mod.
+					if (tt_ptr->io_state.canonical)
 						ZS_STR_OUT(&v, "CANONICAL ");
 					switch(tiod->ichset)
 					{
@@ -389,16 +389,16 @@ void zshow_devices(zshow_out *output)
 						ZS_STR_OUT(&v, interrupt_text);
 					if (hup_on)
 						ZS_STR_OUT(&v, hup_text);
-					if (tt_ptr->io_state.ttsync)  //kt mod
+					if (tt_ptr->io_state.ttsync)
 						ZS_PARM_SP(&v, zshow_ttsy);
 					else
 						ZS_PARM_SP(&v, zshow_nottsy);
-					if (tt_ptr->io_state.hostsync)  //kt mod
+					if (tt_ptr->io_state.hostsync)
 						ZS_PARM_SP(&v, zshow_host);
 					else
 						ZS_PARM_SP(&v, zshow_nohost);
 					/* CONVERT is like HUPENABLE which only show up when enable it */
-					if (tt_ptr->io_state.case_convert)    //kt mod
+					if (tt_ptr->io_state.case_convert)
 						ZS_PARM_SP(&v, zshow_conv);
 					break;
 				case rm:

--- a/sr_unix/zshow_devices.c
+++ b/sr_unix/zshow_devices.c
@@ -256,29 +256,29 @@ void zshow_devices(zshow_out *output)
 						ZS_ONE_OUT(&v, rparen_text);
 						ZS_ONE_OUT(&v, space_text);
 					}
-					if ((int4)(tt_ptr->term_ctrl) & TRM_NOECHO)
+					if (tt_ptr->io_state.devparam_echo == FALSE)  //kt mod
 					{
 						ZS_PARM_SP(&v, zshow_noecho);
 					}
-					if (tt_ptr->term_ctrl & TRM_PASTHRU)
+					if (tt_ptr->io_state.passthru == TRUE)  //kt mod.
 					{
 						ZS_PARM_SP(&v, zshow_past);
 					} else
 					{
 						ZS_PARM_SP(&v, zshow_nopast);
 					}
-					if (!(tt_ptr->term_ctrl & TRM_ESCAPE))
+					if (!(tt_ptr->io_state.escape_processing))  //kt mod.
 					{
 						ZS_PARM_SP(&v, zshow_noesca);
 					}
-					if (tt_ptr->term_ctrl & TRM_READSYNC)
+					if (tt_ptr->io_state.readsync == TRUE)  //kt mod.
 					{
 						ZS_PARM_SP(&v, zshow_reads);
 					} else
 					{
 						ZS_PARM_SP(&v, zshow_noreads);
 					}
-					if (tt_ptr->term_ctrl & TRM_NOTYPEAHD)
+					if (tt_ptr->io_state.no_type_ahead)  //kt mod
 					{
 						ZS_PARM_SP(&v, zshow_notype);
 					} else
@@ -289,8 +289,8 @@ void zshow_devices(zshow_out *output)
 					{
 						ZS_PARM_SP(&v, zshow_nowrap);
 					}
-					mask_out = &tt_ptr->mask_term;
-					if (!tt_ptr->default_mask_term)
+					mask_out = &tt_ptr->io_state.mask_term;  //kt mod
+					if (!tt_ptr->io_state.default_mask_term)  //kt mod
 					{
 						ZS_PARM_EQU(&v, zshow_term);
 						ZS_STR_OUT(&v,dollarc_text);
@@ -345,13 +345,13 @@ void zshow_devices(zshow_out *output)
 							ZS_ONE_OUT(&v,rparen_text);
 						ZS_ONE_OUT(&v, space_text);
 					}
-					if (TT_EDITING & tt_ptr->ext_cap)
+					if BIT_FLAG_IS_ON(TT_EDITING, tt_ptr->io_state.ext_cap) //kt mod
 						ZS_PARM_SP(&v, zshow_edit);
-					if (TT_NOINSERT & tt_ptr->ext_cap)
+					if BIT_FLAG_IS_ON(TT_NOINSERT, tt_ptr->io_state.ext_cap) //kt mod
 						ZS_PARM_SP(&v, zshow_noinse);
-					if (TT_EMPTERM & tt_ptr->ext_cap)
+					if BIT_FLAG_IS_ON(TT_EMPTERM, tt_ptr->io_state.ext_cap)  //kt mod.
 						ZS_PARM_SP(&v, zshow_empterm);
-					if (tt_ptr->canonical)
+					if (tt_ptr->io_state.canonical)	//kt mod.
 						ZS_STR_OUT(&v, "CANONICAL ");
 					switch(tiod->ichset)
 					{
@@ -389,16 +389,16 @@ void zshow_devices(zshow_out *output)
 						ZS_STR_OUT(&v, interrupt_text);
 					if (hup_on)
 						ZS_STR_OUT(&v, hup_text);
-					if (tt_ptr->ttio_struct->c_iflag & IXON)
+					if (tt_ptr->io_state.ttsync)  //kt mod
 						ZS_PARM_SP(&v, zshow_ttsy);
 					else
 						ZS_PARM_SP(&v, zshow_nottsy);
-					if (tt_ptr->ttio_struct->c_iflag & IXOFF)
+					if (tt_ptr->io_state.hostsync)  //kt mod
 						ZS_PARM_SP(&v, zshow_host);
 					else
 						ZS_PARM_SP(&v, zshow_nohost);
 					/* CONVERT is like HUPENABLE which only show up when enable it */
-					if (tt_ptr->term_ctrl & TRM_CONVERT)
+					if (tt_ptr->io_state.case_convert)    //kt mod
 						ZS_PARM_SP(&v, zshow_conv);
 					break;
 				case rm:

--- a/tmg_backup
+++ b/tmg_backup
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+find . -type f -exec grep -l "//kt" {} \; -exec cp --parents {}  /opt/worldvista/EHR/compile/tmg_code_backup/ \;
+


### PR DESCRIPTION

Files affected:
----------------

1. /sr_port/io_ionit.c
2. /sr_unix/dm_read.c
3. /sr_unix/iott_close
4. /sr_unix/iott_open
5. /sr_unix/iott_rdone.c
6. /sr_unix/iott_readfl.c
7. /sr_unix/ iott_resetterm.c
8. /sr_unix/iott_setterm.c
9. /sr_unix/iott_use.c
10. /sr_unix/iottdef.h
11. /sr_unix/readline.c
12. /sr_unix/zshow_devices.c

Problems this merge requests solves:
----------------

I.  **Failure of USE $P:NOECHO to actually suppress output to tty.**

Example:
`USE $P:noecho WRITE "Type here. Chars should NOT echo -->[" HANG 5 WRITE "]",!`

The reason this fails is because at the end of every sub-part of the command, the IO system is reset and doesn't maintain proper IO state. 

II. **Failure to read backspace key.**

Example:
`USE $P:nocanonical WRITE "Type one character.  Try Backspace first: [" READ X#1 WRITE "]",!`

This reason for this is again due to failure to maintain adequate state throughout the entire line of commands.  When the READ occurs, the TTY system, by that point, has been put back into default canonical mode -- which consumes the backspace key.

III. **Inability to read isolated ESC key when is escape-processing mode.**  

This is needed because when implementing an menu system in a terminal application, one needs to be able to allow the user to use arrow keys (e.g. UP, DOWN), but also to cancel the menu with an isolated ESC.  This has become standard behavior for most (if not all) windowed system.  

Example:
`USE $P:escape WRITE "Type isolated ESC key [" read *x:30 w x,"]",! zwr $ZB`

In the above example, if the user types ESC, and then many spaces, nothing seems to happen -- even though READ *X should return after first character is entered.  

Discussion of code changes. 
----------------

In ioinit.c, TTY devices were not initialized.  This left the TTY state, as tracked by ydb, to be out of sync with the actual state of the TTY subsystem. 

There are actually three (3) IO states that need to be tracked by ydb.  First is the IO state upon first entry.  This is so that it can be restored upon exit, returning IO state to its original condition.  Second is an IO state appropriate for interacting with user in direct mode.  In mupip, it is expected that this IO mode will be canonical, where the TTY subsystem manages typing and backspace (erase) key entry.  But in ydb, line editing features necessitate that all chars be delivered immediately, thus canonical mode should be off.  All this needs to be tracked and managed.  Lastly, there is the IO state that either a command in direct mode has specified, or other mumps code from a routine has established.  For example, if code specifies USE $P:NOECHO, this IO state must be managed.  Notice that when working in direct mode, ydb must switch back and forth between the state for direct mode, and the state for executing commands.  Otherwise a USE $P:NOECHO might leave the user unable to see what they type at the command prompt

Because of the need to track multiple states, all of the instances where state was stored had to be modified.  This results in many changes to the code base.  All of the state variables were moved into a struct that could then be used with each managed IO state.  Furthermore, it was discovered that ydb actually needs TWO variables to store ECHO state.  This is because both ydb, and the TTY IO subsystem separately contain echo functionality, and they must each be managed.    

State variables were moved from a system of bit flags into each having a separate boolean variable.  This will result in a small handful of additional bytes being used to store each IO state, but shouldn't affect overall performance.  Because two variables are needed for echo state, the prior bit flag system would have had to be modified regardless to sort out the IO issues.  

Additional discussion may be read as comments in the function iott_compile_ttio_struct() and iott_set_ydb_echo() in file iott_setterm.c

The management of IO device parameters (e.g. NOECHO, NOCANONICAL) had to be modified for management of state adjustment.  There was previously duplicate code for OPEN parameters and USE parameters.  And since that part of the code was already being changed, it was combined into a unified into iott_common_params_to_state() in file iott_use.c

Discussion of comments
----------------

During development of this code fix, I made extensive documentation in the code of the changes being made.  I would comment out the prior code and then add replacement code and put in a "//kt" tag.  After discussion with the ydb team, however, I have removed all these.  I agree that it will make for cleaner code in the ydb codebase.  But I will also point out that I fear this may make matters more difficult in the future if gt.m code changes are made.  If upstream changes were made in a section moved or removed by this code fix, it might be more difficult to detect.  If, instead, that older code was left in but commented out, I think it would be easier to pattern match and compare how that translates into this patch.  Regardless, it is not likely to be an issue.  I suspect upstream gt.m will not be making frequent changes to the TTY IO system of gt.m, as this area is largely old technology.  

Please contact me if there are any questions or concerns at kdtop3 at gmail dot com
